### PR TITLE
NVRTC Batch 2

### DIFF
--- a/include/boost/math/special_functions/cbrt.hpp
+++ b/include/boost/math/special_functions/cbrt.hpp
@@ -1,4 +1,5 @@
 //  (C) Copyright John Maddock 2006.
+//  (C) Copyright Matt Borland 2024.
 //  Use, modification and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +10,8 @@
 #ifdef _MSC_VER
 #pragma once
 #endif
+
+#ifndef __CUDACC_RTC__
 
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/rational.hpp>
@@ -170,6 +173,28 @@ BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T>::type cbrt(T z)
 
 } // namespace math
 } // namespace boost
+
+#else
+
+namespace boost {
+namespace math {
+
+template <typename T>
+__host__ __device__ T cbrt(T x)
+{
+   return ::cbrt(x);
+}
+
+template <>
+__host__ __device__ float cbrt(float x)
+{
+   return ::cbrtf(x);
+}
+
+} // namespace math
+} // namespace boost
+
+#endif // NVRTC
 
 #endif // BOOST_MATH_SF_CBRT_HPP
 

--- a/include/boost/math/special_functions/fpclassify.hpp
+++ b/include/boost/math/special_functions/fpclassify.hpp
@@ -721,37 +721,40 @@ inline bool (isnan)(__float128 x)
 
 #include <boost/math/tools/type_traits.hpp>
 
-template <typename T, boost::math::enable_if_t<boost::math::is_integral_v<T>> = true>
+namespace boost {
+namespace math {
+
+template <typename T, boost::math::enable_if_t<boost::math::is_integral_v<T>, bool> = true>
 inline BOOST_MATH_GPU_ENABLED bool isnan(T x)
 {
    return false;
 }
 
-template <typename T, boost::math::enable_if_t<!boost::math::is_integral_v<T>> = true>
+template <typename T, boost::math::enable_if_t<!boost::math::is_integral_v<T>, bool> = true>
 inline BOOST_MATH_GPU_ENABLED bool isnan(T x)
 {
    return ::isnan(x);
 }
 
-template <typename T, boost::math::enable_if_t<boost::math::is_integral_v<T>> = true>
+template <typename T, boost::math::enable_if_t<boost::math::is_integral_v<T>, bool> = true>
 inline BOOST_MATH_GPU_ENABLED bool isinf(T x)
 {
    return false;
 }
 
-template <typename T, boost::math::enable_if_t<!boost::math::is_integral_v<T>> = true>
+template <typename T, boost::math::enable_if_t<!boost::math::is_integral_v<T>, bool> = true>
 inline BOOST_MATH_GPU_ENABLED bool isinf(T x)
 {
    return ::isinf(x);
 }
 
-template <typename T, boost::math::enable_if_t<boost::math::is_integral_v<T>> = true>
+template <typename T, boost::math::enable_if_t<boost::math::is_integral_v<T>, bool> = true>
 inline BOOST_MATH_GPU_ENABLED bool isfinite(T x)
 {
    return true;
 }
 
-template <typename T, boost::math::enable_if_t<!boost::math::is_integral_v<T>> = true>
+template <typename T, boost::math::enable_if_t<!boost::math::is_integral_v<T>, bool> = true>
 inline BOOST_MATH_GPU_ENABLED bool isfinite(T x)
 {
    return ::isfinite(x);
@@ -784,6 +787,9 @@ inline BOOST_MATH_GPU_ENABLED int fpclassify(T x)
 
    return BOOST_MATH_FP_NORMAL;
 }
+
+} // Namespace math
+} // Namespace boost
 
 #endif // BOOST_MATH_NVRTC_ENABLED
 

--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -2284,23 +2284,25 @@ BOOST_MATH_GPU_ENABLED inline tools::promote_args_t<T1, T2>
 
 #else
 
+#include <boost/math/tools/config.hpp>
+
 namespace boost {
 namespace math {
 
-inline __host__ __device__ float tgamma(float x) { return ::tgammaf(x); }
-inline __host__ __device__ double tgamma(double x) { return ::tgamma(x); }
+inline BOOST_MATH_GPU_ENABLED float tgamma(float x) { return ::tgammaf(x); }
+inline BOOST_MATH_GPU_ENABLED double tgamma(double x) { return ::tgamma(x); }
 
 template <typename T, typename Policy>
-inline __host__ __device__ T tgamma(T x, const Policy&)
+inline BOOST_MATH_GPU_ENABLED T tgamma(T x, const Policy&)
 {
    return boost::math::tgamma(x);
 }
 
-inline __host__ __device__ float lgamma(float x) { return ::lgammaf(x); }
-inline __host__ __device__ double lgamma(double x) { return ::lgamma(x); }
+inline BOOST_MATH_GPU_ENABLED float lgamma(float x) { return ::lgammaf(x); }
+inline BOOST_MATH_GPU_ENABLED double lgamma(double x) { return ::lgamma(x); }
 
 template <typename T, typename Policy>
-inline __host__ __device__ T lgamma(T x, const Policy&)
+inline BOOST_MATH_GPU_ENABLED T lgamma(T x, const Policy&)
 {
    return boost::math::lgamma(x);
 }

--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -2296,6 +2296,15 @@ inline __host__ __device__ T tgamma(T x, const Policy&)
    return boost::math::tgamma(x);
 }
 
+inline __host__ __device__ float lgamma(float x) { return ::lgammaf(x); }
+inline __host__ __device__ double lgamma(double x) { return ::lgamma(x); }
+
+template <typename T, typename Policy>
+inline __host__ __device__ T lgamma(T x, const Policy&)
+{
+   return boost::math::lgamma(x);
+}
+
 } // namespace math
 } // namespace boost
 

--- a/include/boost/math/special_functions/sign.hpp
+++ b/include/boost/math/special_functions/sign.hpp
@@ -218,6 +218,12 @@ __host__ __device__ T copysign(T x, T y)
 }
 
 template <typename T>
+__host__ __device__ float copysign(float x, float y)
+{
+    return ::copysignf(x, y);
+}
+
+template <typename T>
 __host__ __device__ T sign(T z)
 {
     return (z == 0) ? 0 : ::signbit(z) ? -1 : 1;

--- a/include/boost/math/special_functions/sign.hpp
+++ b/include/boost/math/special_functions/sign.hpp
@@ -14,6 +14,8 @@
 #pragma once
 #endif
 
+#ifndef __CUDACC_RTC__
+
 #include <boost/math/tools/config.hpp>
 #include <boost/math/special_functions/math_fwd.hpp>
 #include <boost/math/special_functions/detail/fp_traits.hpp>
@@ -192,6 +194,39 @@ BOOST_MATH_GPU_ENABLED inline typename tools::promote_args_permissive<T, U>::typ
 } // namespace math
 } // namespace boost
 
+#else // NVRTC alias versions
+
+namespace boost {
+namespace math {
+
+template <typename T>
+__host__ __device__ int signbit(T x)
+{
+    return ::signbit(x);
+}
+
+template <typename T>
+__host__ __device__ T changesign(T x)
+{
+    return -x;
+}
+
+template <typename T>
+__host__ __device__ T copysign(T x, T y)
+{
+    return ::copysign(x, y);
+}
+
+template <typename T>
+__host__ __device__ T sign(T z)
+{
+    return (z == 0) ? 0 : ::signbit(z) ? -1 : 1;
+}
+
+} // namespace math
+} // namespace boost
+
+#endif // __CUDACC_RTC__
 
 #endif // BOOST_MATH_TOOLS_SIGN_HPP
 

--- a/include/boost/math/special_functions/sign.hpp
+++ b/include/boost/math/special_functions/sign.hpp
@@ -217,7 +217,7 @@ __host__ __device__ T copysign(T x, T y)
     return ::copysign(x, y);
 }
 
-template <typename T>
+template <>
 __host__ __device__ float copysign(float x, float y)
 {
     return ::copysignf(x, y);

--- a/include/boost/math/special_functions/sign.hpp
+++ b/include/boost/math/special_functions/sign.hpp
@@ -196,35 +196,37 @@ BOOST_MATH_GPU_ENABLED inline typename tools::promote_args_permissive<T, U>::typ
 
 #else // NVRTC alias versions
 
+#include <boost/math/tools/config.hpp>
+
 namespace boost {
 namespace math {
 
 template <typename T>
-__host__ __device__ int signbit(T x)
+BOOST_MATH_GPU_ENABLED int signbit(T x)
 {
     return ::signbit(x);
 }
 
 template <typename T>
-__host__ __device__ T changesign(T x)
+BOOST_MATH_GPU_ENABLED T changesign(T x)
 {
     return -x;
 }
 
 template <typename T>
-__host__ __device__ T copysign(T x, T y)
+BOOST_MATH_GPU_ENABLED T copysign(T x, T y)
 {
     return ::copysign(x, y);
 }
 
 template <>
-__host__ __device__ float copysign(float x, float y)
+BOOST_MATH_GPU_ENABLED float copysign(float x, float y)
 {
     return ::copysignf(x, y);
 }
 
 template <typename T>
-__host__ __device__ T sign(T z)
+BOOST_MATH_GPU_ENABLED T sign(T z)
 {
     return (z == 0) ? 0 : ::signbit(z) ? -1 : 1;
 }

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -769,6 +769,8 @@ BOOST_MATH_GPU_ENABLED constexpr T cuda_safe_max(const T& a, const T& b) { retur
 #endif
 
 #define BOOST_MATH_NVRTC_ENABLED
+#define BOOST_MATH_CUDA_ENABLED
+#define BOOST_MATH_HAS_GPU_SUPPORT
 
 #define BOOST_MATH_GPU_ENABLED __host__ __device__
 

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -784,8 +784,8 @@ template <class T>
 BOOST_MATH_GPU_ENABLED constexpr void gpu_safe_swap(T& a, T& b) { T t(a); a = b; b = t; }
 
 #define BOOST_MATH_GPU_SAFE_SWAP(a, b) gpu_safe_swap(a, b)
-#define BOOST_MATH_GPU_SAFE_MIN(a, b) ::min(a, b)
-#define BOOST_MATH_GPU_SAFE_MAX(a, b) ::max(a, b)
+#define BOOST_MATH_GPU_SAFE_MIN(a, b) (::min)(a, b)
+#define BOOST_MATH_GPU_SAFE_MAX(a, b) (::max)(a, b)
 
 #define BOOST_MATH_FP_NAN 0
 #define BOOST_MATH_FP_INFINITE 1

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -775,7 +775,7 @@ BOOST_MATH_GPU_ENABLED constexpr T cuda_safe_max(const T& a, const T& b) { retur
 #endif
 
 #define BOOST_MATH_NVRTC_ENABLED
-#define BOOST_MATH_CUDA_ENABLED
+#define BOOST_MATH_ENABLE_CUDA
 #define BOOST_MATH_HAS_GPU_SUPPORT
 
 #define BOOST_MATH_GPU_ENABLED __host__ __device__

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -743,7 +743,7 @@ BOOST_MATH_GPU_ENABLED constexpr T cuda_safe_max(const T& a, const T& b) { retur
 // See if we can inline them instead
 
 #if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L
-#  define BOOST_MATH_STATIC_CONSTEXPR inline constexpr
+#  define BOOST_MATH_INLINE_CONSTEXPR inline constexpr
 #  define BOOST_MATH_STATIC static
 #  ifndef BOOST_MATH_HAS_GPU_SUPPORT
 #    define BOOST_MATH_STATIC_LOCAL_VARIABLE static
@@ -752,11 +752,11 @@ BOOST_MATH_GPU_ENABLED constexpr T cuda_safe_max(const T& a, const T& b) { retur
 #  endif
 #else
 #  ifndef BOOST_MATH_HAS_GPU_SUPPORT
-#    define BOOST_MATH_STATIC_CONSTEXPR static constexpr
+#    define BOOST_MATH_INLINE_CONSTEXPR static constexpr
 #    define BOOST_MATH_STATIC static
 #    define BOOST_MATH_STATIC_LOCAL_VARIABLE
 #  else
-#    define BOOST_MATH_STATIC_CONSTEXPR constexpr
+#    define BOOST_MATH_INLINE_CONSTEXPR constexpr
 #    define BOOST_MATH_STATIC constexpr
 #    define BOOST_MATH_STATIC_LOCAL_VARIABLE static
 #  endif
@@ -792,6 +792,12 @@ BOOST_MATH_GPU_ENABLED constexpr void gpu_safe_swap(T& a, T& b) { T t(a); a = b;
 #define BOOST_MATH_FP_ZERO 2
 #define BOOST_MATH_FP_SUBNORMAL 3
 #define BOOST_MATH_FP_NORMAL 4
+
+#if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L
+#  define BOOST_MATH_INLINE_CONSTEXPR inline constexpr
+#else
+#  define BOOST_MATH_INLINE_CONSTEXPR constexpr
+#endif
 
 #endif // NVRTC
 

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -11,6 +11,8 @@
 #pragma once
 #endif
 
+#ifndef __CUDACC_RTC__
+
 #include <boost/math/tools/is_standalone.hpp>
 
 // Minimum language standard transition
@@ -759,6 +761,25 @@ BOOST_MATH_GPU_ENABLED constexpr T cuda_safe_max(const T& a, const T& b) { retur
 #    define BOOST_MATH_STATIC_LOCAL_VARIABLE static
 #  endif
 #endif
+
+#else // Special section for CUDA NVRTC to ensure we consume no headers
+
+#ifndef BOOST_MATH_STANDALONE
+#  define BOOST_MATH_STANDALONE
+#endif
+
+#define BOOST_MATH_NVRTC_ENABLED
+
+#define BOOST_MATH_GPU_ENABLED __host__ __device__
+
+template <class T>
+BOOST_MATH_GPU_ENABLED constexpr void gpu_safe_swap(T& a, T& b) { T t(a); a = b; b = t; }
+
+#define BOOST_MATH_GPU_SAFE_SWAP(a, b) gpu_safe_swap(a, b)
+#define BOOST_MATH_GPU_SAFE_MIN(a, b) ::min(a, b)
+#define BOOST_MATH_GPU_SAFE_MAX(a, b) ::max(a, b)
+
+#endif // NVRTC
 
 #endif // BOOST_MATH_TOOLS_CONFIG_HPP
 

--- a/include/boost/math/tools/config.hpp
+++ b/include/boost/math/tools/config.hpp
@@ -762,6 +762,12 @@ BOOST_MATH_GPU_ENABLED constexpr T cuda_safe_max(const T& a, const T& b) { retur
 #  endif
 #endif
 
+#define BOOST_MATH_FP_NAN FP_NAN
+#define BOOST_MATH_FP_INFINITE FP_INFINITE
+#define BOOST_MATH_FP_ZERO FP_ZERO
+#define BOOST_MATH_FP_SUBNORMAL FP_SUBNORMAL
+#define BOOST_MATH_FP_NORMAL FP_NORMAL
+
 #else // Special section for CUDA NVRTC to ensure we consume no headers
 
 #ifndef BOOST_MATH_STANDALONE
@@ -780,6 +786,12 @@ BOOST_MATH_GPU_ENABLED constexpr void gpu_safe_swap(T& a, T& b) { T t(a); a = b;
 #define BOOST_MATH_GPU_SAFE_SWAP(a, b) gpu_safe_swap(a, b)
 #define BOOST_MATH_GPU_SAFE_MIN(a, b) ::min(a, b)
 #define BOOST_MATH_GPU_SAFE_MAX(a, b) ::max(a, b)
+
+#define BOOST_MATH_FP_NAN 0
+#define BOOST_MATH_FP_INFINITE 1
+#define BOOST_MATH_FP_ZERO 2
+#define BOOST_MATH_FP_SUBNORMAL 3
+#define BOOST_MATH_FP_NORMAL 4
 
 #endif // NVRTC
 

--- a/include/boost/math/tools/tuple.hpp
+++ b/include/boost/math/tools/tuple.hpp
@@ -8,10 +8,8 @@
 #define BOOST_MATH_TUPLE_HPP_INCLUDED
 
 #include <boost/math/tools/config.hpp>
-#include <boost/math/tools/cxx03_warn.hpp>
-#include <tuple>
 
-#ifdef BOOST_MATH_ENABLE_CUDA
+#ifdef BOOST_MATH_CUDA_ENABLED
 
 #include <thrust/pair.h>
 #include <thrust/tuple.h>
@@ -35,6 +33,8 @@ using thrust::tuple_element;
 } // namespace boost
 
 #else
+
+#include <tuple>
 
 namespace boost { 
 namespace math {

--- a/include/boost/math/tools/tuple.hpp
+++ b/include/boost/math/tools/tuple.hpp
@@ -9,7 +9,7 @@
 
 #include <boost/math/tools/config.hpp>
 
-#ifdef BOOST_MATH_CUDA_ENABLED
+#ifdef BOOST_MATH_ENABLE_CUDA
 
 #include <thrust/pair.h>
 #include <thrust/tuple.h>

--- a/include/boost/math/tools/type_traits.hpp
+++ b/include/boost/math/tools/type_traits.hpp
@@ -399,9 +399,6 @@ template <typename T>
 BOOST_MATH_INLINE_CONSTEXPR bool is_final_v = boost::math::is_final<T>::value;
 
 template <typename T>
-BOOST_MATH_INLINE_CONSTEXPR bool is_aggregate_v = boost::math::is_aggregate<T>::value;
-
-template <typename T>
 BOOST_MATH_INLINE_CONSTEXPR bool is_signed_v = boost::math::is_signed<T>::value;
 
 template <typename T>
@@ -443,14 +440,14 @@ BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_move_constructible_v = boost::math
 template <typename T>
 BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_move_constructible_v = boost::math::is_nothrow_move_constructible<T>::value;
 
-template <typename T>
-BOOST_MATH_INLINE_CONSTEXPR bool is_assignable_v = boost::math::is_assignable<T>::value;
+template <typename T, typename U>
+BOOST_MATH_INLINE_CONSTEXPR bool is_assignable_v = boost::math::is_assignable<T, U>::value;
 
-template <typename T>
-BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_assignable_v = boost::math::is_trivially_assignable<T>::value;
+template <typename T, typename U>
+BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_assignable_v = boost::math::is_trivially_assignable<T, U>::value;
 
-template <typename T>
-BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_assignable_v = boost::math::is_nothrow_assignable<T>::value;
+template <typename T, typename U>
+BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_assignable_v = boost::math::is_nothrow_assignable<T, U>::value;
 
 template <typename T>
 BOOST_MATH_INLINE_CONSTEXPR bool is_copy_assignable_v = boost::math::is_copy_assignable<T>::value;

--- a/include/boost/math/tools/type_traits.hpp
+++ b/include/boost/math/tools/type_traits.hpp
@@ -1,0 +1,43 @@
+//  Copyright (c) 2024 Matt Borland
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+//  Regular use of <type_traits> is not compatible with CUDA
+//  Adds aliases to unify the support
+//  Also adds convience overloads like is_same_v so we don't have to wait for C++17
+
+#ifndef BOOST_MATH_TOOLS_TYPE_TRAITS
+#define BOOST_MATH_TOOLS_TYPE_TRAITS
+
+#include <boost/math/tools/config.hpp>
+
+namespace boost {
+namespace math {
+
+#ifdef BOOST_MATH_CUDA_ENABLED
+
+using cuda::std::is_void;
+using cuda::std::is_integral;
+using cuda::std::enable_if_t;
+
+#else // STD versions
+
+#include <type_traits>
+
+using std::is_void;
+using std::is_integral;
+using std::enable_if_t;
+
+#endif 
+
+template <typename T>
+BOOST_MATH_STATIC_CONSTEXPR bool is_void_v = boost::math::is_void<T>::value;
+
+template <typename T>
+BOOST_MATH_STATIC_CONSTEXPR bool is_integral_v = boost::math::is_integral<T>::value;
+
+} // namespace math
+} // namespace boost
+
+#endif // BOOST_MATH_TOOLS_TYPE_TRAITS

--- a/include/boost/math/tools/type_traits.hpp
+++ b/include/boost/math/tools/type_traits.hpp
@@ -17,6 +17,8 @@ namespace math {
 
 #ifdef BOOST_MATH_CUDA_ENABLED
 
+#include <cuda/std/type_traits>
+
 using cuda::std::is_void;
 using cuda::std::is_integral;
 using cuda::std::enable_if_t;
@@ -32,10 +34,10 @@ using std::enable_if_t;
 #endif 
 
 template <typename T>
-BOOST_MATH_STATIC_CONSTEXPR bool is_void_v = boost::math::is_void<T>::value;
+BOOST_MATH_INLINE_CONSTEXPR bool is_void_v = boost::math::is_void<T>::value;
 
 template <typename T>
-BOOST_MATH_STATIC_CONSTEXPR bool is_integral_v = boost::math::is_integral<T>::value;
+BOOST_MATH_INLINE_CONSTEXPR bool is_integral_v = boost::math::is_integral<T>::value;
 
 } // namespace math
 } // namespace boost

--- a/include/boost/math/tools/type_traits.hpp
+++ b/include/boost/math/tools/type_traits.hpp
@@ -15,7 +15,7 @@
 namespace boost {
 namespace math {
 
-#ifdef BOOST_MATH_CUDA_ENABLED
+#ifdef BOOST_MATH_ENABLE_CUDA
 
 #include <cuda/std/type_traits>
 

--- a/include/boost/math/tools/type_traits.hpp
+++ b/include/boost/math/tools/type_traits.hpp
@@ -19,25 +19,474 @@ namespace math {
 
 #include <cuda/std/type_traits>
 
+// Helper classes
+using cuda::std::integral_constant;
+using cuda::std::true_type;
+using cuda::std::false_type;
+
+// Primary type categories
 using cuda::std::is_void;
+using cuda::std::is_null_pointer;
 using cuda::std::is_integral;
+using cuda::std::is_floating_point;
+using cuda::std::is_array;
+using cuda::std::is_enum;
+using cuda::std::is_union;
+using cuda::std::is_class;
+using cuda::std::is_function;
+using cuda::std::is_pointer;
+using cuda::std::is_lvalue_reference;
+using cuda::std::is_rvalue_reference;
+using cuda::std::is_member_object_pointer;
+using cuda::std::is_member_function_pointer;
+
+// Composite Type Categories
+using cuda::std::is_fundamental;
+using cuda::std::is_arithmetic;
+using cuda::std::is_scalar;
+using cuda::std::is_object;
+using cuda::std::is_compound;
+using cuda::std::is_reference;
+using cuda::std::is_member_pointer;
+
+// Type properties
+using cuda::std::is_const;
+using cuda::std::is_volatile;
+using cuda::std::is_trivial;
+using cuda::std::is_trivially_copyable;
+using cuda::std::is_standard_layout;
+using cuda::std::is_empty;
+using cuda::std::is_polymorphic;
+using cuda::std::is_abstract;
+using cuda::std::is_final;
+using cuda::std::is_signed;
+using cuda::std::is_unsigned; 
+
+// Supported Operations
+using cuda::std::is_constructible;
+using cuda::std::is_trivially_constructible;
+using cuda::std::is_nothrow_constructible;
+
+using cuda::std::is_default_constructible;
+using cuda::std::is_trivially_default_constructible;
+using cuda::std::is_nothrow_default_constructible;
+
+using cuda::std::is_copy_constructible;
+using cuda::std::is_trivially_copy_constructible;
+using cuda::std::is_nothrow_copy_constructible;
+
+using cuda::std::is_move_constructible;
+using cuda::std::is_trivially_move_constructible;
+using cuda::std::is_nothrow_move_constructible;
+
+using cuda::std::is_assignable;
+using cuda::std::is_trivially_assignable;
+using cuda::std::is_nothrow_assignable;
+
+using cuda::std::is_copy_assignable;
+using cuda::std::is_trivially_copy_assignable;
+using cuda::std::is_nothrow_copy_assignable;
+
+using cuda::std::is_move_assignable;
+using cuda::std::is_trivially_move_assignable;
+using cuda::std::is_nothrow_move_assignable;
+
+using cuda::std::is_destructible;
+using cuda::std::is_trivially_destructible;
+using cuda::std::is_nothrow_destructible;
+
+using cuda::std::has_virtual_destructor;
+
+// Property Queries
+using cuda::std::alignment_of;
+using cuda::std::rank;
+using cuda::std::extent;
+
+// Type Relationships
+using cuda::std::is_same;
+using cuda::std::is_base_of;
+using cuda::std::is_convertible;
+
+// Const-volatility specifiers
+using cuda::std::remove_cv;
+using cuda::std::remove_cv_t;
+using cuda::std::remove_const;
+using cuda::std::remove_const_t;
+using cuda::std::remove_volatile;
+using cuda::std::remove_volatile_t;
+using cuda::std::add_cv;
+using cuda::std::add_cv_t;
+using cuda::std::add_const;
+using cuda::std::add_const_t;
+using cuda::std::add_volatile;
+using cuda::std::add_volatile_t;
+
+// References
+using cuda::std::remove_reference;
+using cuda::std::remove_reference_t;
+using cuda::std::add_lvalue_reference;
+using cuda::std::add_lvalue_reference_t;
+using cuda::std::add_rvalue_reference;
+using cuda::std::add_rvalue_reference_t;
+
+// Pointers
+using cuda::std::remove_pointer;
+using cuda::std::remove_pointer_t;
+using cuda::std::add_pointer;
+using cuda::std::add_pointer_t;
+
+// Sign Modifiers
+using cuda::std::make_signed;
+using cuda::std::make_signed_t;
+using cuda::std::make_unsigned;
+using cuda::std::make_unsigned_t;
+
+// Arrays
+using cuda::std::remove_extent;
+using cuda::std::remove_extent_t;
+using cuda::std::remove_all_extents;
+using cuda::std::remove_all_extents_t;
+
+// Misc transformations
+using cuda::std::decay;
+using cuda::std::decay_t;
+using cuda::std::enable_if;
 using cuda::std::enable_if_t;
+using cuda::std::conditional;
+using cuda::std::conditional_t;
+using cuda::std::common_type;
+using cuda::std::common_type_t;
+using cuda::std::underlying_type;
+using cuda::std::underlying_type_t;
 
 #else // STD versions
 
 #include <type_traits>
 
+// Helper classes
+using std::integral_constant;
+using std::true_type;
+using std::false_type;
+
+// Primary type categories
 using std::is_void;
+using std::is_null_pointer;
 using std::is_integral;
+using std::is_floating_point;
+using std::is_array;
+using std::is_enum;
+using std::is_union;
+using std::is_class;
+using std::is_function;
+using std::is_pointer;
+using std::is_lvalue_reference;
+using std::is_rvalue_reference;
+using std::is_member_object_pointer;
+using std::is_member_function_pointer;
+
+// Composite Type Categories
+using std::is_fundamental;
+using std::is_arithmetic;
+using std::is_scalar;
+using std::is_object;
+using std::is_compound;
+using std::is_reference;
+using std::is_member_pointer;
+
+// Type properties
+using std::is_const;
+using std::is_volatile;
+using std::is_trivial;
+using std::is_trivially_copyable;
+using std::is_standard_layout;
+using std::is_empty;
+using std::is_polymorphic;
+using std::is_abstract;
+using std::is_final;
+using std::is_signed;
+using std::is_unsigned; 
+
+// Supported Operations
+using std::is_constructible;
+using std::is_trivially_constructible;
+using std::is_nothrow_constructible;
+
+using std::is_default_constructible;
+using std::is_trivially_default_constructible;
+using std::is_nothrow_default_constructible;
+
+using std::is_copy_constructible;
+using std::is_trivially_copy_constructible;
+using std::is_nothrow_copy_constructible;
+
+using std::is_move_constructible;
+using std::is_trivially_move_constructible;
+using std::is_nothrow_move_constructible;
+
+using std::is_assignable;
+using std::is_trivially_assignable;
+using std::is_nothrow_assignable;
+
+using std::is_copy_assignable;
+using std::is_trivially_copy_assignable;
+using std::is_nothrow_copy_assignable;
+
+using std::is_move_assignable;
+using std::is_trivially_move_assignable;
+using std::is_nothrow_move_assignable;
+
+using std::is_destructible;
+using std::is_trivially_destructible;
+using std::is_nothrow_destructible;
+
+using std::has_virtual_destructor;
+
+// Property Queries
+using std::alignment_of;
+using std::rank;
+using std::extent;
+
+// Type Relationships
+using std::is_same;
+using std::is_base_of;
+using std::is_convertible;
+
+// Const-volatility specifiers
+using std::remove_cv;
+using std::remove_cv_t;
+using std::remove_const;
+using std::remove_const_t;
+using std::remove_volatile;
+using std::remove_volatile_t;
+using std::add_cv;
+using std::add_cv_t;
+using std::add_const;
+using std::add_const_t;
+using std::add_volatile;
+using std::add_volatile_t;
+
+// References
+using std::remove_reference;
+using std::remove_reference_t;
+using std::add_lvalue_reference;
+using std::add_lvalue_reference_t;
+using std::add_rvalue_reference;
+using std::add_rvalue_reference_t;
+
+// Pointers
+using std::remove_pointer;
+using std::remove_pointer_t;
+using std::add_pointer;
+using std::add_pointer_t;
+
+// Sign Modifiers
+using std::make_signed;
+using std::make_signed_t;
+using std::make_unsigned;
+using std::make_unsigned_t;
+
+// Arrays
+using std::remove_extent;
+using std::remove_extent_t;
+using std::remove_all_extents;
+using std::remove_all_extents_t;
+
+// Misc transformations
+using std::decay;
+using std::decay_t;
+using std::enable_if;
 using std::enable_if_t;
+using std::conditional;
+using std::conditional_t;
+using std::common_type;
+using std::common_type_t;
+using std::underlying_type;
+using std::underlying_type_t;
 
 #endif 
+
+template <bool B>
+using bool_constant = boost::math::integral_constant<bool, B>;
 
 template <typename T>
 BOOST_MATH_INLINE_CONSTEXPR bool is_void_v = boost::math::is_void<T>::value;
 
 template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_null_pointer_v = boost::math::is_null_pointer<T>::value;
+
+template <typename T>
 BOOST_MATH_INLINE_CONSTEXPR bool is_integral_v = boost::math::is_integral<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_floating_point_v = boost::math::is_floating_point<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_array_v = boost::math::is_array<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_enum_v = boost::math::is_enum<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_union_v = boost::math::is_union<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_class_v = boost::math::is_class<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_function_v = boost::math::is_function<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_pointer_v = boost::math::is_pointer<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_lvalue_reference_v = boost::math::is_lvalue_reference<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_rvalue_reference_v = boost::math::is_rvalue_reference<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_member_object_pointer_v = boost::math::is_member_object_pointer<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_member_function_pointer_v = boost::math::is_member_function_pointer<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_fundamental_v = boost::math::is_fundamental<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_arithmetic_v = boost::math::is_arithmetic<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_scalar_v = boost::math::is_scalar<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_object_v = boost::math::is_object<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_compound_v = boost::math::is_compound<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_reference_v = boost::math::is_reference<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_member_pointer_v = boost::math::is_member_pointer<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_const_v = boost::math::is_const<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_volatile_v = boost::math::is_volatile<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_trivial_v = boost::math::is_trivial<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_copyable_v = boost::math::is_trivially_copyable<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_standard_layout_v = boost::math::is_standard_layout<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_empty_v = boost::math::is_empty<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_polymorphic_v = boost::math::is_polymorphic<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_abstract_v = boost::math::is_abstract<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_final_v = boost::math::is_final<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_aggregate_v = boost::math::is_aggregate<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_signed_v = boost::math::is_signed<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_unsigned_v = boost::math::is_unsigned<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_constructible_v = boost::math::is_constructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_constructible_v = boost::math::is_trivially_constructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_constructible_v = boost::math::is_nothrow_constructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_default_constructible_v = boost::math::is_default_constructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_default_constructible_v = boost::math::is_trivially_default_constructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_default_constructible_v = boost::math::is_nothrow_default_constructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_copy_constructible_v = boost::math::is_copy_constructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_copy_constructible_v = boost::math::is_trivially_copy_constructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_copy_constructible_v = boost::math::is_nothrow_copy_constructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_move_constructible_v = boost::math::is_move_constructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_move_constructible_v = boost::math::is_trivially_move_constructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_move_constructible_v = boost::math::is_nothrow_move_constructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_assignable_v = boost::math::is_assignable<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_assignable_v = boost::math::is_trivially_assignable<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_assignable_v = boost::math::is_nothrow_assignable<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_copy_assignable_v = boost::math::is_copy_assignable<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_copy_assignable_v = boost::math::is_trivially_copy_assignable<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_copy_assignable_v = boost::math::is_nothrow_copy_assignable<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_move_assignable_v = boost::math::is_move_assignable<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_move_assignable_v = boost::math::is_trivially_move_assignable<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_move_assignable_v = boost::math::is_nothrow_move_assignable<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_destructible_v = boost::math::is_destructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_trivially_destructible_v = boost::math::is_trivially_destructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool is_nothrow_destructible_v = boost::math::is_nothrow_destructible<T>::value;
+
+template <typename T>
+BOOST_MATH_INLINE_CONSTEXPR bool has_virtual_destructor_v = boost::math::has_virtual_destructor<T>::value;
+
+template <typename T, typename U>
+BOOST_MATH_INLINE_CONSTEXPR bool is_same_v = boost::math::is_same<T, U>::value;
+
+template <typename T, typename U>
+BOOST_MATH_INLINE_CONSTEXPR bool is_base_of_v = boost::math::is_base_of<T, U>::value;
 
 } // namespace math
 } // namespace boost

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,12 +10,13 @@ if(HAVE_BOOST_TEST)
 
         message(STATUS "Building boost.cuda_math with CUDA")
 
+        find_package(CUDA REQUIRED)
         enable_language(CUDA)
         set(CMAKE_CUDA_EXTENSIONS OFF)
 
         enable_testing()
 
-        boost_test_jamfile(FILE cuda_jamfile LINK_LIBRARIES Boost::cuda_math Boost::assert Boost::concept_check Boost::config Boost::core Boost::integer Boost::lexical_cast Boost::multiprecision Boost::predef Boost::random Boost::static_assert Boost::throw_exception Boost::unit_test_framework )
+        boost_test_jamfile(FILE cuda_jamfile LINK_LIBRARIES Boost::cuda_math Boost::assert Boost::concept_check Boost::config Boost::core Boost::integer Boost::lexical_cast Boost::multiprecision Boost::predef Boost::random Boost::static_assert Boost::throw_exception Boost::unit_test_framework ${CUDA_LIBRARIES} INCLUDE_DIRECTORIES ${CUDA_INCLUDE_DIRS} )
 
     elseif (BOOST_MATH_ENABLE_NVRTC)
 

--- a/test/cuda_jamfile
+++ b/test/cuda_jamfile
@@ -9,12 +9,6 @@ project : requirements
     [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_constexpr ]
     ;
 
-# Autodiff Tests
-run test_autodiff_1.cpp ;
-
-# Tools Tests
-run test_polynomial.cpp ;
-
 # Distributions
 run test_arcsine.cpp ;
 run test_arcsine_cdf_double.cu ;
@@ -30,7 +24,6 @@ run test_bernoulli_pdf_double.cu ;
 run test_bernoulli_pdf_float.cu ;
 run test_bernoulli_range_support_double.cu ;
 run test_bernoulli_range_support_float.cu ;
-run test_binomial.cpp ;
 run test_cauchy_cdf_double.cu ;
 run test_cauchy_cdf_float.cu ;
 run test_cauchy_pdf_double.cu ;

--- a/test/nvrtc_jamfile
+++ b/test/nvrtc_jamfile
@@ -12,6 +12,8 @@ project : requirements
 # Special Functions
 run test_cbrt_nvrtc_double.cpp ;
 run test_cbrt_nvrtc_float.cpp ;
+run test_fpclassify_nvrtc_double.cpp ;
+run test_fpclassify_nvrtc_float.cpp ;
 run test_gamma_nvrtc_double.cpp ;
 run test_gamma_nvrtc_float.cpp ;
 run test_sign_nvrtc_double.cpp ;

--- a/test/nvrtc_jamfile
+++ b/test/nvrtc_jamfile
@@ -10,6 +10,8 @@ project : requirements
     ;
 
 # Special Functions
+run test_cbrt_nvrtc_double.cpp ;
+run test_cbrt_nvrtc_float.cpp ;
 run test_gamma_nvrtc_double.cpp ;
 run test_gamma_nvrtc_float.cpp ;
 run test_sign_nvrtc_double.cpp ;

--- a/test/nvrtc_jamfile
+++ b/test/nvrtc_jamfile
@@ -12,3 +12,5 @@ project : requirements
 # Special Functions
 run test_gamma_nvrtc_double.cpp ;
 run test_gamma_nvrtc_float.cpp ;
+run test_sign_nvrtc_double.cpp ;
+run test_sign_nvrtc_float.cpp ;

--- a/test/test_cbrt_nvrtc_double.cpp
+++ b/test/test_cbrt_nvrtc_double.cpp
@@ -1,0 +1,186 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/cbrt.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <nvrtc.h>
+
+typedef double float_type;
+
+const char* cuda_kernel = R"(
+typedef double float_type;
+#include <boost/math/special_functions/cbrt.hpp>
+extern "C" __global__ 
+void test_cbrt_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::cbrt(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_cbrt_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_cbrt_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_cbrt_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            auto res = boost::math::cbrt(h_in1[i]);
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/test/test_cbrt_nvrtc_float.cpp
+++ b/test/test_cbrt_nvrtc_float.cpp
@@ -1,0 +1,186 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/cbrt.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <nvrtc.h>
+
+typedef float float_type;
+
+const char* cuda_kernel = R"(
+typedef float float_type;
+#include <boost/math/special_functions/cbrt.hpp>
+extern "C" __global__ 
+void test_cbrt_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::cbrt(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_cbrt_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_cbrt_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_cbrt_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            auto res = boost::math::cbrt(h_in1[i]);
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/test/test_fpclassify_nvrtc_double.cpp
+++ b/test/test_fpclassify_nvrtc_double.cpp
@@ -1,0 +1,198 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+// Must be included first
+#include <nvrtc.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+
+typedef float float_type;
+
+const char* cuda_kernel = R"(
+typedef float float_type;
+#include <cuda/std/type_traits>
+#include <boost/math/special_functions/fpclassify.hpp>
+extern "C" __global__ 
+void test_gamma_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::isnan(in1[i]) + 
+                 boost::math::isinf(in1[i]) + 
+                 boost::math::isfinite(in1[i]) +
+                 boost::math::isnormal(in1[i]) +
+                 boost::math::fpclassify(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_gamma_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_gamma_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_gamma_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            auto res = boost::math::isnan(h_in1[i]) + 
+                       boost::math::isinf(h_in1[i]) + 
+                       boost::math::isfinite(h_in1[i]) +
+                       boost::math::isnormal(h_in1[i]) +
+                       boost::math::fpclassify(h_in1[i]);
+                       
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/test/test_fpclassify_nvrtc_float.cpp
+++ b/test/test_fpclassify_nvrtc_float.cpp
@@ -1,0 +1,198 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+// Must be included first
+#include <nvrtc.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+
+typedef float float_type;
+
+const char* cuda_kernel = R"(
+typedef float float_type;
+#include <cuda/std/type_traits>
+#include <boost/math/special_functions/fpclassify.hpp>
+extern "C" __global__ 
+void test_gamma_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::isnan(in1[i]) + 
+                 boost::math::isinf(in1[i]) + 
+                 boost::math::isfinite(in1[i]) +
+                 boost::math::isnormal(in1[i]) +
+                 boost::math::fpclassify(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_gamma_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_gamma_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_gamma_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            auto res = boost::math::isnan(h_in1[i]) + 
+                       boost::math::isinf(h_in1[i]) + 
+                       boost::math::isfinite(h_in1[i]) +
+                       boost::math::isnormal(h_in1[i]) +
+                       boost::math::fpclassify(h_in1[i]);
+                       
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/test/test_gamma_nvrtc_double.cpp
+++ b/test/test_gamma_nvrtc_double.cpp
@@ -24,12 +24,12 @@ const char* cuda_kernel = R"(
 typedef double float_type;
 #include <boost/math/special_functions/gamma.hpp>
 extern "C" __global__ 
-void test_gamma_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+void test_gamma_kernel(const float_type *in1, const float_type *in2, float_type *out, int numElements)
 {
     int i = blockDim.x * blockIdx.x + threadIdx.x;
     if (i < numElements)
     {
-        out[i] = boost::math::tgamma(in1[i]);
+        out[i] = boost::math::tgamma(in1[i]) + boost::math::lgamma(in2[i]);
     }
 }
 )";
@@ -150,7 +150,7 @@ int main()
         // Verify Result
         for (int i = 0; i < numElements; ++i) 
         {
-            auto res = boost::math::tgamma(h_in1[i]);
+            auto res = boost::math::tgamma(h_in1[i]) + boost::math::lgamma(h_in2[i]);
             if (std::isfinite(res))
             {
                 if (boost::math::epsilon_difference(res, h_out[i]) > 300)

--- a/test/test_gamma_nvrtc_float.cpp
+++ b/test/test_gamma_nvrtc_float.cpp
@@ -24,12 +24,12 @@ const char* cuda_kernel = R"(
 typedef float float_type;
 #include <boost/math/special_functions/gamma.hpp>
 extern "C" __global__ 
-void test_gamma_kernel(const float_type *in1, const float_type*, float_type *out, int numElements)
+void test_gamma_kernel(const float_type *in1, const float_type *in2, float_type *out, int numElements)
 {
     int i = blockDim.x * blockIdx.x + threadIdx.x;
     if (i < numElements)
     {
-        out[i] = boost::math::tgamma(in1[i]);
+        out[i] = boost::math::tgamma(in1[i]) + boost::math::lgamma(in2[i]);
     }
 }
 )";
@@ -150,7 +150,7 @@ int main()
         // Verify Result
         for (int i = 0; i < numElements; ++i) 
         {
-            auto res = boost::math::tgamma(h_in1[i]);
+            auto res = boost::math::tgamma(h_in1[i]) + boost::math::lgamma(h_in2[i]);
             if (std::isfinite(res))
             {
                 if (boost::math::epsilon_difference(res, h_out[i]) > 300)

--- a/test/test_sign_nvrtc.cpp
+++ b/test/test_sign_nvrtc.cpp
@@ -1,0 +1,190 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/sign.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <nvrtc.h>
+
+const char* cuda_kernel = R"(
+#include <boost/math/special_functions/sign.hpp>
+extern "C" __global__ 
+void test_gamma_kernel(const float *in1, const float *in2, float *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::signbit(in1[i]) + 
+                 boost::math::changesign(in1[i]) + 
+                 boost::math::copysign(in1[i], in2[i]) +
+                 boost::math::sign(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_gamma_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_gamma_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_gamma_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float *h_in1, *h_in2, *h_out;
+        float *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float[numElements];
+        h_in2 = new float[numElements];
+        h_out = new float[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float>(dist(rng));
+            h_in2[i] = static_cast<float>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            auto res = boost::math::signbit(h_in1[i]) + 
+                       boost::math::changesign(h_in1[i]) + 
+                       boost::math::copysign(h_in1[i], h_in2[i]) +
+                       boost::math::sign(h_in1[i]);
+                       
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/test/test_sign_nvrtc_double.cpp
+++ b/test/test_sign_nvrtc_double.cpp
@@ -18,10 +18,13 @@
 #include <cuda_runtime.h>
 #include <nvrtc.h>
 
+typedef double float_type;
+
 const char* cuda_kernel = R"(
+typedef double float_type;
 #include <boost/math/special_functions/sign.hpp>
 extern "C" __global__ 
-void test_gamma_kernel(const float *in1, const float *in2, float *out, int numElements)
+void test_gamma_kernel(const float_type *in1, const float_type *in2, float_type *out, int numElements)
 {
     int i = blockDim.x * blockIdx.x + threadIdx.x;
     if (i < numElements)
@@ -116,36 +119,36 @@ int main()
         checkCUError(cuModuleGetFunction(&kernel, module, "test_gamma_kernel"), "Failed to get kernel function");
 
         int numElements = 5000;
-        float *h_in1, *h_in2, *h_out;
-        float *d_in1, *d_in2, *d_out;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
 
         // Allocate memory on the host
-        h_in1 = new float[numElements];
-        h_in2 = new float[numElements];
-        h_out = new float[numElements];
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
 
         // Initialize input arrays
         std::mt19937_64 rng(42);
-        std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1.0f);
         for (int i = 0; i < numElements; ++i) 
         {
-            h_in1[i] = static_cast<float>(dist(rng));
-            h_in2[i] = static_cast<float>(dist(rng));
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
         }
 
-        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float)), "Failed to allocate device memory for d_in1");
-        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float)), "Failed to allocate device memory for d_in2");
-        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float)), "Failed to allocate device memory for d_out");
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
 
-        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
-        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
 
         int blockSize = 256;
         int numBlocks = (numElements + blockSize - 1) / blockSize;
         void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
         checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
 
-        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
 
         // Verify Result
         for (int i = 0; i < numElements; ++i) 

--- a/test/test_sign_nvrtc_float.cpp
+++ b/test/test_sign_nvrtc_float.cpp
@@ -1,0 +1,193 @@
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <exception>
+#include <boost/math/special_functions/sign.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <nvrtc.h>
+
+typedef float float_type;
+
+const char* cuda_kernel = R"(
+typedef float float_type;
+#include <boost/math/special_functions/sign.hpp>
+extern "C" __global__ 
+void test_gamma_kernel(const float_type *in1, const float_type *in2, float_type *out, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < numElements)
+    {
+        out[i] = boost::math::signbit(in1[i]) + 
+                 boost::math::changesign(in1[i]) + 
+                 boost::math::copysign(in1[i], in2[i]) +
+                 boost::math::sign(in1[i]);
+    }
+}
+)";
+
+void checkCUDAError(cudaError_t result, const char* msg)
+{
+    if (result != cudaSuccess)
+    {
+        std::cerr << msg << ": " << cudaGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkCUError(CUresult result, const char* msg)
+{
+    if (result != CUDA_SUCCESS)
+    {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << msg << ": " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+void checkNVRTCError(nvrtcResult result, const char* msg)
+{
+    if (result != NVRTC_SUCCESS)
+    {
+        std::cerr << msg << ": " << nvrtcGetErrorString(result) << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() 
+{
+    try
+    {
+        // Initialize CUDA driver API
+        checkCUError(cuInit(0), "Failed to initialize CUDA");
+
+        // Create CUDA context
+        CUcontext context;
+        CUdevice device;
+        checkCUError(cuDeviceGet(&device, 0), "Failed to get CUDA device");
+        checkCUError(cuCtxCreate(&context, 0, device), "Failed to create CUDA context");
+
+        nvrtcProgram prog;
+        nvrtcResult res;
+
+        res = nvrtcCreateProgram(&prog, cuda_kernel, "test_gamma_kernel.cu", 0, nullptr, nullptr);
+        checkNVRTCError(res, "Failed to create NVRTC program");
+
+        nvrtcAddNameExpression(prog, "test_gamma_kernel");
+
+        #ifdef BOOST_MATH_NVRTC_CI_RUN
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/"};
+        #else
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/"};
+        #endif
+
+        // Compile the program
+        res = nvrtcCompileProgram(prog, sizeof(opts) / sizeof(const char*), opts);
+        if (res != NVRTC_SUCCESS) 
+        {
+            size_t log_size;
+            nvrtcGetProgramLogSize(prog, &log_size);
+            char* log = new char[log_size];
+            nvrtcGetProgramLog(prog, log);
+            std::cerr << "Compilation failed:\n" << log << std::endl;
+            delete[] log;
+            exit(EXIT_FAILURE);
+        }
+
+        // Get PTX from the program
+        size_t ptx_size;
+        nvrtcGetPTXSize(prog, &ptx_size);
+        char* ptx = new char[ptx_size];
+        nvrtcGetPTX(prog, ptx);
+
+        // Load PTX into CUDA module
+        CUmodule module;
+        CUfunction kernel;
+        checkCUError(cuModuleLoadDataEx(&module, ptx, 0, 0, 0), "Failed to load module");
+        checkCUError(cuModuleGetFunction(&kernel, module, "test_gamma_kernel"), "Failed to get kernel function");
+
+        int numElements = 5000;
+        float_type *h_in1, *h_in2, *h_out;
+        float_type *d_in1, *d_in2, *d_out;
+
+        // Allocate memory on the host
+        h_in1 = new float_type[numElements];
+        h_in2 = new float_type[numElements];
+        h_out = new float_type[numElements];
+
+        // Initialize input arrays
+        std::mt19937_64 rng(42);
+        std::uniform_real_distribution<float_type> dist(0.0f, 1.0f);
+        for (int i = 0; i < numElements; ++i) 
+        {
+            h_in1[i] = static_cast<float_type>(dist(rng));
+            h_in2[i] = static_cast<float_type>(dist(rng));
+        }
+
+        checkCUDAError(cudaMalloc(&d_in1, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in1");
+        checkCUDAError(cudaMalloc(&d_in2, numElements * sizeof(float_type)), "Failed to allocate device memory for d_in2");
+        checkCUDAError(cudaMalloc(&d_out, numElements * sizeof(float_type)), "Failed to allocate device memory for d_out");
+
+        checkCUDAError(cudaMemcpy(d_in1, h_in1, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in1");
+        checkCUDAError(cudaMemcpy(d_in2, h_in2, numElements * sizeof(float_type), cudaMemcpyHostToDevice), "Failed to copy data to device for d_in2");
+
+        int blockSize = 256;
+        int numBlocks = (numElements + blockSize - 1) / blockSize;
+        void* args[] = { &d_in1, &d_in2, &d_out, &numElements };
+        checkCUError(cuLaunchKernel(kernel, numBlocks, 1, 1, blockSize, 1, 1, 0, 0, args, 0), "Kernel launch failed");
+
+        checkCUDAError(cudaMemcpy(h_out, d_out, numElements * sizeof(float_type), cudaMemcpyDeviceToHost), "Failed to copy data back to host for h_out");
+
+        // Verify Result
+        for (int i = 0; i < numElements; ++i) 
+        {
+            auto res = boost::math::signbit(h_in1[i]) + 
+                       boost::math::changesign(h_in1[i]) + 
+                       boost::math::copysign(h_in1[i], h_in2[i]) +
+                       boost::math::sign(h_in1[i]);
+                       
+            if (std::isfinite(res))
+            {
+                if (boost::math::epsilon_difference(res, h_out[i]) > 300)
+                {
+                    std::cout << "error at line: " << i
+                            << "\nParallel: " << h_out[i]
+                            << "\n  Serial: " << res
+                            << "\n    Dist: " << boost::math::epsilon_difference(res, h_out[i]) << std::endl;
+                }
+            }
+        }
+
+        cudaFree(d_in1);
+        cudaFree(d_in2);
+        cudaFree(d_out);
+        delete[] h_in1;
+        delete[] h_in2;
+        delete[] h_out;
+
+        nvrtcDestroyProgram(&prog);
+        delete[] ptx;
+
+        cuCtxDestroy(context);
+
+        std::cout << "Kernel executed successfully." << std::endl;
+        return 0;
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << "Stopped with exception: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}


### PR DESCRIPTION
This begins implementing workarounds for `<type_traits`> and NVRTC specific configuration options

Adds support for: sign, cbrt, lgamma, and all the fpclassify functions