### PR TITLE
GPU Batch 7 Testing

### DIFF
--- a/include/boost/math/special_functions/bernoulli.hpp
+++ b/include/boost/math/special_functions/bernoulli.hpp
@@ -11,16 +11,18 @@
 #ifndef _BOOST_BERNOULLI_B2N_2013_05_30_HPP_
 #define _BOOST_BERNOULLI_B2N_2013_05_30_HPP_
 
+#include <boost/math/tools/config.hpp>
 #include <boost/math/special_functions/math_fwd.hpp>
 #include <boost/math/special_functions/detail/unchecked_bernoulli.hpp>
 #include <boost/math/special_functions/detail/bernoulli_details.hpp>
+#include <boost/math/policies/error_handling.hpp>
 
 namespace boost { namespace math {
 
 namespace detail {
 
 template <class T, class OutputIterator, class Policy, int N>
-OutputIterator bernoulli_number_imp(OutputIterator out, std::size_t start, std::size_t n, const Policy& pol, const std::integral_constant<int, N>& tag)
+BOOST_MATH_GPU_ENABLED OutputIterator bernoulli_number_imp(OutputIterator out, std::size_t start, std::size_t n, const Policy& pol, const std::integral_constant<int, N>& tag)
 {
    for(std::size_t i = start; (i <= max_bernoulli_b2n<T>::value) && (i < start + n); ++i)
    {
@@ -38,7 +40,7 @@ OutputIterator bernoulli_number_imp(OutputIterator out, std::size_t start, std::
 }
 
 template <class T, class OutputIterator, class Policy>
-OutputIterator bernoulli_number_imp(OutputIterator out, std::size_t start, std::size_t n, const Policy& pol, const std::integral_constant<int, 0>& tag)
+BOOST_MATH_GPU_ENABLED OutputIterator bernoulli_number_imp(OutputIterator out, std::size_t start, std::size_t n, const Policy& pol, const std::integral_constant<int, 0>& tag)
 {
    for(std::size_t i = start; (i <= max_bernoulli_b2n<T>::value) && (i < start + n); ++i)
    {
@@ -59,7 +61,7 @@ OutputIterator bernoulli_number_imp(OutputIterator out, std::size_t start, std::
 } // namespace detail
 
 template <class T, class Policy>
-inline T bernoulli_b2n(const int i, const Policy &pol)
+BOOST_MATH_GPU_ENABLED inline T bernoulli_b2n(const int i, const Policy &pol)
 {
    using tag_type = std::integral_constant<int, detail::bernoulli_imp_variant<T>::value>;
    if(i < 0)
@@ -73,13 +75,13 @@ inline T bernoulli_b2n(const int i, const Policy &pol)
 }
 
 template <class T>
-inline T bernoulli_b2n(const int i)
+BOOST_MATH_GPU_ENABLED inline T bernoulli_b2n(const int i)
 {
    return boost::math::bernoulli_b2n<T>(i, policies::policy<>());
 }
 
 template <class T, class OutputIterator, class Policy>
-inline OutputIterator bernoulli_b2n(const int start_index,
+BOOST_MATH_GPU_ENABLED inline OutputIterator bernoulli_b2n(const int start_index,
                                     const unsigned number_of_bernoullis_b2n,
                                     OutputIterator out_it,
                                     const Policy& pol)
@@ -95,7 +97,7 @@ inline OutputIterator bernoulli_b2n(const int start_index,
 }
 
 template <class T, class OutputIterator>
-inline OutputIterator bernoulli_b2n(const int start_index,
+BOOST_MATH_GPU_ENABLED inline OutputIterator bernoulli_b2n(const int start_index,
                                     const unsigned number_of_bernoullis_b2n,
                                     OutputIterator out_it)
 {
@@ -103,7 +105,7 @@ inline OutputIterator bernoulli_b2n(const int start_index,
 }
 
 template <class T, class Policy>
-inline T tangent_t2n(const int i, const Policy &pol)
+BOOST_MATH_GPU_ENABLED inline T tangent_t2n(const int i, const Policy &pol)
 {
    if(i < 0)
    {
@@ -116,13 +118,13 @@ inline T tangent_t2n(const int i, const Policy &pol)
 }
 
 template <class T>
-inline T tangent_t2n(const int i)
+BOOST_MATH_GPU_ENABLED inline T tangent_t2n(const int i)
 {
    return boost::math::tangent_t2n<T>(i, policies::policy<>());
 }
 
 template <class T, class OutputIterator, class Policy>
-inline OutputIterator tangent_t2n(const int start_index,
+BOOST_MATH_GPU_ENABLED inline OutputIterator tangent_t2n(const int start_index,
                                     const unsigned number_of_tangent_t2n,
                                     OutputIterator out_it,
                                     const Policy& pol)
@@ -137,7 +139,7 @@ inline OutputIterator tangent_t2n(const int start_index,
 }
 
 template <class T, class OutputIterator>
-inline OutputIterator tangent_t2n(const int start_index,
+BOOST_MATH_GPU_ENABLED inline OutputIterator tangent_t2n(const int start_index,
                                     const unsigned number_of_tangent_t2n,
                                     OutputIterator out_it)
 {

--- a/include/boost/math/special_functions/bernoulli.hpp
+++ b/include/boost/math/special_functions/bernoulli.hpp
@@ -12,6 +12,8 @@
 #define _BOOST_BERNOULLI_B2N_2013_05_30_HPP_
 
 #include <boost/math/tools/config.hpp>
+#include <boost/math/tools/cstdint.hpp>
+#include <boost/math/tools/type_traits.hpp>
 #include <boost/math/special_functions/math_fwd.hpp>
 #include <boost/math/special_functions/detail/unchecked_bernoulli.hpp>
 #include <boost/math/special_functions/detail/bernoulli_details.hpp>
@@ -22,15 +24,15 @@ namespace boost { namespace math {
 namespace detail {
 
 template <class T, class OutputIterator, class Policy, int N>
-BOOST_MATH_GPU_ENABLED OutputIterator bernoulli_number_imp(OutputIterator out, std::size_t start, std::size_t n, const Policy& pol, const std::integral_constant<int, N>& tag)
+BOOST_MATH_GPU_ENABLED OutputIterator bernoulli_number_imp(OutputIterator out, boost::math::size_t start, boost::math::size_t n, const Policy& pol, const boost::math::integral_constant<int, N>& tag)
 {
-   for(std::size_t i = start; (i <= max_bernoulli_b2n<T>::value) && (i < start + n); ++i)
+   for(boost::math::size_t i = start; (i <= max_bernoulli_b2n<T>::value) && (i < start + n); ++i)
    {
       *out = unchecked_bernoulli_imp<T>(i, tag);
       ++out;
    }
 
-   for(std::size_t i = (std::max)(static_cast<std::size_t>(max_bernoulli_b2n<T>::value + 1), start); i < start + n; ++i)
+   for(boost::math::size_t i = BOOST_MATH_GPU_SAFE_MAX(static_cast<boost::math::size_t>(max_bernoulli_b2n<T>::value + 1), start); i < start + n; ++i)
    {
       // We must overflow:
       *out = (i & 1 ? 1 : -1) * policies::raise_overflow_error<T>("boost::math::bernoulli_b2n<%1%>(n)", nullptr, T(i), pol);
@@ -40,11 +42,11 @@ BOOST_MATH_GPU_ENABLED OutputIterator bernoulli_number_imp(OutputIterator out, s
 }
 
 template <class T, class OutputIterator, class Policy>
-BOOST_MATH_GPU_ENABLED OutputIterator bernoulli_number_imp(OutputIterator out, std::size_t start, std::size_t n, const Policy& pol, const std::integral_constant<int, 0>& tag)
+BOOST_MATH_GPU_ENABLED OutputIterator bernoulli_number_imp(OutputIterator out, boost::math::size_t start, boost::math::size_t n, const Policy& pol, const boost::math::integral_constant<int, 0>& tag)
 {
-   for(std::size_t i = start; (i <= max_bernoulli_b2n<T>::value) && (i < start + n); ++i)
+   for(boost::math::size_t i = start; (i <= max_bernoulli_b2n<T>::value) && (i < start + n); ++i)
    {
-      *out = unchecked_bernoulli_imp<T>(i, tag);
+      *out = unchecked_bernoulli_imp<T>(i, tag());
       ++out;
    }
    //
@@ -63,14 +65,14 @@ BOOST_MATH_GPU_ENABLED OutputIterator bernoulli_number_imp(OutputIterator out, s
 template <class T, class Policy>
 BOOST_MATH_GPU_ENABLED inline T bernoulli_b2n(const int i, const Policy &pol)
 {
-   using tag_type = std::integral_constant<int, detail::bernoulli_imp_variant<T>::value>;
+   using tag_type = boost::math::integral_constant<int, detail::bernoulli_imp_variant<T>::value>;
    if(i < 0)
    {
       return policies::raise_domain_error<T>("boost::math::bernoulli_b2n<%1%>", "Index should be >= 0 but got %1%", T(i), pol);
    }
 
    T result {};
-   boost::math::detail::bernoulli_number_imp<T>(&result, static_cast<std::size_t>(i), 1u, pol, tag_type());
+   boost::math::detail::bernoulli_number_imp<T>(&result, static_cast<boost::math::size_t>(i), 1u, pol, tag_type());
    return result;
 }
 
@@ -86,7 +88,7 @@ BOOST_MATH_GPU_ENABLED inline OutputIterator bernoulli_b2n(const int start_index
                                     OutputIterator out_it,
                                     const Policy& pol)
 {
-   using tag_type = std::integral_constant<int, detail::bernoulli_imp_variant<T>::value>;
+   using tag_type = boost::math::integral_constant<int, detail::bernoulli_imp_variant<T>::value>;
    if(start_index < 0)
    {
       *out_it = policies::raise_domain_error<T>("boost::math::bernoulli_b2n<%1%>", "Index should be >= 0 but got %1%", T(start_index), pol);

--- a/include/boost/math/special_functions/detail/gamma_inva.hpp
+++ b/include/boost/math/special_functions/detail/gamma_inva.hpp
@@ -1,4 +1,5 @@
 //  (C) Copyright John Maddock 2006.
+//  (C) Copyright Matt Borland 2024.
 //  Use, modification and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -17,7 +18,7 @@
 #pragma once
 #endif
 
-#include <cstdint>
+#include <boost/math/tools/config.hpp>
 #include <boost/math/tools/toms748_solve.hpp>
 
 namespace boost{ namespace math{ namespace detail{
@@ -25,8 +26,8 @@ namespace boost{ namespace math{ namespace detail{
 template <class T, class Policy>
 struct gamma_inva_t
 {
-   gamma_inva_t(T z_, T p_, bool invert_) : z(z_), p(p_), invert(invert_) {}
-   T operator()(T a)
+   BOOST_MATH_GPU_ENABLED gamma_inva_t(T z_, T p_, bool invert_) : z(z_), p(p_), invert(invert_) {}
+   BOOST_MATH_GPU_ENABLED T operator()(T a)
    {
       return invert ? p - boost::math::gamma_q(a, z, Policy()) : boost::math::gamma_p(a, z, Policy()) - p;
    }
@@ -36,7 +37,7 @@ private:
 };
 
 template <class T, class Policy>
-T inverse_poisson_cornish_fisher(T lambda, T p, T q, const Policy& pol)
+BOOST_MATH_GPU_ENABLED T inverse_poisson_cornish_fisher(T lambda, T p, T q, const Policy& pol)
 {
    BOOST_MATH_STD_USING
    // mean:
@@ -67,7 +68,7 @@ T inverse_poisson_cornish_fisher(T lambda, T p, T q, const Policy& pol)
 }
 
 template <class T, class Policy>
-T gamma_inva_imp(const T& z, const T& p, const T& q, const Policy& pol)
+BOOST_MATH_GPU_ENABLED T gamma_inva_imp(const T& z, const T& p, const T& q, const Policy& pol)
 {
    BOOST_MATH_STD_USING  // for ADL of std lib math functions
    //
@@ -151,7 +152,7 @@ T gamma_inva_imp(const T& z, const T& p, const T& q, const Policy& pol)
 } // namespace detail
 
 template <class T1, class T2, class Policy>
-inline typename tools::promote_args<T1, T2>::type
+BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T1, T2>::type
    gamma_p_inva(T1 x, T2 p, const Policy& pol)
 {
    typedef typename tools::promote_args<T1, T2>::type result_type;
@@ -181,7 +182,7 @@ inline typename tools::promote_args<T1, T2>::type
 }
 
 template <class T1, class T2, class Policy>
-inline typename tools::promote_args<T1, T2>::type
+BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T1, T2>::type
    gamma_q_inva(T1 x, T2 q, const Policy& pol)
 {
    typedef typename tools::promote_args<T1, T2>::type result_type;
@@ -211,14 +212,14 @@ inline typename tools::promote_args<T1, T2>::type
 }
 
 template <class T1, class T2>
-inline typename tools::promote_args<T1, T2>::type
+BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T1, T2>::type
    gamma_p_inva(T1 x, T2 p)
 {
    return boost::math::gamma_p_inva(x, p, policies::policy<>());
 }
 
 template <class T1, class T2>
-inline typename tools::promote_args<T1, T2>::type
+BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T1, T2>::type
    gamma_q_inva(T1 x, T2 q)
 {
    return boost::math::gamma_q_inva(x, q, policies::policy<>());

--- a/include/boost/math/special_functions/detail/igamma_inverse.hpp
+++ b/include/boost/math/special_functions/detail/igamma_inverse.hpp
@@ -1,4 +1,5 @@
 //  (C) Copyright John Maddock 2006.
+//  (C) Copyright Matt Borland 2024.
 //  Use, modification and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,6 +11,8 @@
 #pragma once
 #endif
 
+#include <boost/math/tools/config.hpp>
+#include <boost/math/tools/cstdint.hpp>
 #include <boost/math/tools/tuple.hpp>
 #include <boost/math/special_functions/gamma.hpp>
 #include <boost/math/special_functions/sign.hpp>
@@ -21,7 +24,7 @@ namespace boost{ namespace math{
 namespace detail{
 
 template <class T>
-T find_inverse_s(T p, T q)
+BOOST_MATH_GPU_ENABLED T find_inverse_s(T p, T q)
 {
    //
    // Computation of the Incomplete Gamma Function Ratios and their Inverse
@@ -41,8 +44,8 @@ T find_inverse_s(T p, T q)
    {
       t = sqrt(-2 * log(q));
    }
-   static const double a[4] = { 3.31125922108741, 11.6616720288968, 4.28342155967104, 0.213623493715853 };
-   static const double b[5] = { 1, 6.61053765625462, 6.40691597760039, 1.27364489782223, 0.3611708101884203e-1 };
+   BOOST_MATH_STATIC const double a[4] = { 3.31125922108741, 11.6616720288968, 4.28342155967104, 0.213623493715853 };
+   BOOST_MATH_STATIC const double b[5] = { 1, 6.61053765625462, 6.40691597760039, 1.27364489782223, 0.3611708101884203e-1 };
    T s = t - tools::evaluate_polynomial(a, t) / tools::evaluate_polynomial(b, t);
    if(p < T(0.5))
       s = -s;
@@ -50,7 +53,7 @@ T find_inverse_s(T p, T q)
 }
 
 template <class T>
-T didonato_SN(T a, T x, unsigned N, T tolerance = 0)
+BOOST_MATH_GPU_ENABLED T didonato_SN(T a, T x, unsigned N, T tolerance = 0)
 {
    //
    // Computation of the Incomplete Gamma Function Ratios and their Inverse
@@ -77,7 +80,7 @@ T didonato_SN(T a, T x, unsigned N, T tolerance = 0)
 }
 
 template <class T, class Policy>
-inline T didonato_FN(T p, T a, T x, unsigned N, T tolerance, const Policy& pol)
+BOOST_MATH_GPU_ENABLED inline T didonato_FN(T p, T a, T x, unsigned N, T tolerance, const Policy& pol)
 {
    //
    // Computation of the Incomplete Gamma Function Ratios and their Inverse
@@ -93,7 +96,7 @@ inline T didonato_FN(T p, T a, T x, unsigned N, T tolerance, const Policy& pol)
 }
 
 template <class T, class Policy>
-T find_inverse_gamma(T a, T p, T q, const Policy& pol, bool* p_has_10_digits)
+BOOST_MATH_GPU_ENABLED T find_inverse_gamma(T a, T p, T q, const Policy& pol, bool* p_has_10_digits)
 {
    //
    // In order to understand what's going on here, you will
@@ -233,7 +236,7 @@ T find_inverse_gamma(T a, T p, T q, const Policy& pol, bool* p_has_10_digits)
          }
          else
          {
-            T D = (std::max)(T(2), T(a * (a - 1)));
+            T D = BOOST_MATH_GPU_SAFE_MAX(T(2), T(a * (a - 1)));
             T lg = boost::math::lgamma(a, pol);
             T lb = log(q) + lg;
             if(lb < -D * T(2.3))
@@ -315,7 +318,7 @@ T find_inverse_gamma(T a, T p, T q, const Policy& pol, bool* p_has_10_digits)
 template <class T, class Policy>
 struct gamma_p_inverse_func
 {
-   gamma_p_inverse_func(T a_, T p_, bool inv) : a(a_), p(p_), invert(inv)
+   BOOST_MATH_GPU_ENABLED gamma_p_inverse_func(T a_, T p_, bool inv) : a(a_), p(p_), invert(inv)
    {
       //
       // If p is too near 1 then P(x) - p suffers from cancellation
@@ -333,7 +336,7 @@ struct gamma_p_inverse_func
       }
    }
 
-   boost::math::tuple<T, T, T> operator()(const T& x)const
+   BOOST_MATH_GPU_ENABLED boost::math::tuple<T, T, T> operator()(const T& x)const
    {
       BOOST_FPU_EXCEPTION_GUARD
       //
@@ -395,11 +398,11 @@ private:
 };
 
 template <class T, class Policy>
-T gamma_p_inv_imp(T a, T p, const Policy& pol)
+BOOST_MATH_GPU_ENABLED T gamma_p_inv_imp(T a, T p, const Policy& pol)
 {
    BOOST_MATH_STD_USING  // ADL of std functions.
 
-   static const char* function = "boost::math::gamma_p_inv<%1%>(%1%, %1%)";
+   BOOST_MATH_STATIC const char* function = "boost::math::gamma_p_inv<%1%>(%1%, %1%)";
 
    BOOST_MATH_INSTRUMENT_VARIABLE(a);
    BOOST_MATH_INSTRUMENT_VARIABLE(p);
@@ -442,7 +445,9 @@ T gamma_p_inv_imp(T a, T p, const Policy& pol)
    //
    // Go ahead and iterate:
    //
-   std::uintmax_t max_iter = policies::get_max_root_iterations<Policy>();
+   boost::math::uintmax_t max_iter = policies::get_max_root_iterations<Policy>();
+   
+   #ifndef BOOST_MATH_HAS_GPU_SUPPORT
    guess = tools::halley_iterate(
       detail::gamma_p_inverse_func<T, Policy>(a, p, false),
       guess,
@@ -450,6 +455,16 @@ T gamma_p_inv_imp(T a, T p, const Policy& pol)
       tools::max_value<T>(),
       digits,
       max_iter);
+   #else
+   guess = tools::newton_raphson_iterate(
+      detail::gamma_p_inverse_func<T, Policy>(a, p, false),
+      guess,
+      lower,
+      tools::max_value<T>(),
+      digits,
+      max_iter);
+   #endif
+   
    policies::check_root_iterations<T>(function, max_iter, pol);
    BOOST_MATH_INSTRUMENT_VARIABLE(guess);
    if(guess == lower)
@@ -458,11 +473,11 @@ T gamma_p_inv_imp(T a, T p, const Policy& pol)
 }
 
 template <class T, class Policy>
-T gamma_q_inv_imp(T a, T q, const Policy& pol)
+BOOST_MATH_GPU_ENABLED T gamma_q_inv_imp(T a, T q, const Policy& pol)
 {
    BOOST_MATH_STD_USING  // ADL of std functions.
 
-   static const char* function = "boost::math::gamma_q_inv<%1%>(%1%, %1%)";
+   BOOST_MATH_STATIC const char* function = "boost::math::gamma_q_inv<%1%>(%1%, %1%)";
 
    if(a <= 0)
       return policies::raise_domain_error<T>(function, "Argument a in the incomplete gamma function inverse must be >= 0 (got a=%1%).", a, pol);
@@ -501,7 +516,9 @@ T gamma_q_inv_imp(T a, T q, const Policy& pol)
    //
    // Go ahead and iterate:
    //
-   std::uintmax_t max_iter = policies::get_max_root_iterations<Policy>();
+   boost::math::uintmax_t max_iter = policies::get_max_root_iterations<Policy>();
+
+   #ifndef BOOST_MATH_HAS_GPU_SUPPORT
    guess = tools::halley_iterate(
       detail::gamma_p_inverse_func<T, Policy>(a, q, true),
       guess,
@@ -509,6 +526,16 @@ T gamma_q_inv_imp(T a, T q, const Policy& pol)
       tools::max_value<T>(),
       digits,
       max_iter);
+   #else
+   guess = tools::newton_raphson_iterate(
+      detail::gamma_p_inverse_func<T, Policy>(a, q, true),
+      guess,
+      lower,
+      tools::max_value<T>(),
+      digits,
+      max_iter);
+   #endif
+
    policies::check_root_iterations<T>(function, max_iter, pol);
    if(guess == lower)
       guess = policies::raise_underflow_error<T>(function, "Expected result known to be non-zero, but is smaller than the smallest available number.", pol);
@@ -518,7 +545,7 @@ T gamma_q_inv_imp(T a, T q, const Policy& pol)
 } // namespace detail
 
 template <class T1, class T2, class Policy>
-inline typename tools::promote_args<T1, T2>::type
+BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T1, T2>::type
    gamma_p_inv(T1 a, T2 p, const Policy& pol)
 {
    typedef typename tools::promote_args<T1, T2>::type result_type;
@@ -528,7 +555,7 @@ inline typename tools::promote_args<T1, T2>::type
 }
 
 template <class T1, class T2, class Policy>
-inline typename tools::promote_args<T1, T2>::type
+BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T1, T2>::type
    gamma_q_inv(T1 a, T2 p, const Policy& pol)
 {
    typedef typename tools::promote_args<T1, T2>::type result_type;
@@ -538,14 +565,14 @@ inline typename tools::promote_args<T1, T2>::type
 }
 
 template <class T1, class T2>
-inline typename tools::promote_args<T1, T2>::type
+BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T1, T2>::type
    gamma_p_inv(T1 a, T2 p)
 {
    return gamma_p_inv(a, p, policies::policy<>());
 }
 
 template <class T1, class T2>
-inline typename tools::promote_args<T1, T2>::type
+BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T1, T2>::type
    gamma_q_inv(T1 a, T2 p)
 {
    return gamma_q_inv(a, p, policies::policy<>());

--- a/include/boost/math/special_functions/detail/igamma_large.hpp
+++ b/include/boost/math/special_functions/detail/igamma_large.hpp
@@ -61,6 +61,12 @@
 #endif
 
 #include <boost/math/tools/config.hpp>
+#include <boost/math/tools/numeric_limits.hpp>
+#include <boost/math/tools/type_traits.hpp>
+#include <boost/math/tools/polynomial.hpp>
+#include <boost/math/special_functions/log1p.hpp>
+#include <boost/math/special_functions/erf.hpp>
+#include <boost/math/constants/constants.hpp>
 
 namespace boost{ namespace math{ namespace detail{
 
@@ -68,7 +74,7 @@ namespace boost{ namespace math{ namespace detail{
 // when T is unsuitable to be passed to these routines:
 //
 template <class T, class Policy>
-inline T igamma_temme_large(T, T, const Policy& /* pol */, const std::integral_constant<int, 0>&)
+BOOST_MATH_GPU_ENABLED inline T igamma_temme_large(T, T, const Policy& /* pol */, const boost::math::integral_constant<int, 0>&)
 {
    // stub function, should never actually be called
    BOOST_MATH_ASSERT(0);
@@ -79,7 +85,7 @@ inline T igamma_temme_large(T, T, const Policy& /* pol */, const std::integral_c
 // (80-bit long double, or 10^-20).
 //
 template <class T, class Policy>
-T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<int, 64>&)
+BOOST_MATH_GPU_ENABLED T igamma_temme_large(T a, T x, const Policy& pol, const boost::math::integral_constant<int, 64>&)
 {
    BOOST_MATH_STD_USING // ADL of std functions
    T sigma = (x - a) / a;
@@ -91,7 +97,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
 
    T workspace[13];
 
-   static const T C0[] = {
+   BOOST_MATH_STATIC const T C0[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.333333333333333333333),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.0833333333333333333333),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.0148148148148148148148),
@@ -114,7 +120,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[0] = tools::evaluate_polynomial(C0, z);
 
-   static const T C1[] = {
+   BOOST_MATH_STATIC const T C1[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.00185185185185185185185),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.00347222222222222222222),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.00264550264550264550265),
@@ -135,7 +141,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[1] = tools::evaluate_polynomial(C1, z);
 
-   static const T C2[] = {
+   BOOST_MATH_STATIC const T C2[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.00413359788359788359788),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.00268132716049382716049),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.000771604938271604938272),
@@ -154,7 +160,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[2] = tools::evaluate_polynomial(C2, z);
 
-   static const T C3[] = {
+   BOOST_MATH_STATIC const T C3[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.000649434156378600823045),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.000229472093621399176955),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.000469189494395255712128),
@@ -171,7 +177,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[3] = tools::evaluate_polynomial(C3, z);
 
-   static const T C4[] = {
+   BOOST_MATH_STATIC const T C4[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.000861888290916711698605),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.000784039221720066627474),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.000299072480303190179733),
@@ -186,7 +192,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[4] = tools::evaluate_polynomial(C4, z);
 
-   static const T C5[] = {
+   BOOST_MATH_STATIC const T C5[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.000336798553366358150309),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.697281375836585777429e-4),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.000277275324495939207873),
@@ -199,7 +205,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[5] = tools::evaluate_polynomial(C5, z);
 
-   static const T C6[] = {
+   BOOST_MATH_STATIC const T C6[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.000531307936463992223166),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.000592166437353693882865),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.000270878209671804482771),
@@ -214,7 +220,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[6] = tools::evaluate_polynomial(C6, z);
 
-   static const T C7[] = {
+   BOOST_MATH_STATIC const T C7[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.000344367606892377671254),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.517179090826059219337e-4),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.000334931610811422363117),
@@ -227,7 +233,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[7] = tools::evaluate_polynomial(C7, z);
 
-   static const T C8[] = {
+   BOOST_MATH_STATIC const T C8[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.000652623918595309418922),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.000839498720672087279993),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.000438297098541721005061),
@@ -238,7 +244,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[8] = tools::evaluate_polynomial(C8, z);
 
-   static const T C9[] = {
+   BOOST_MATH_STATIC const T C9[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.000596761290192746250124),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.720489541602001055909e-4),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.000678230883766732836162),
@@ -247,14 +253,14 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[9] = tools::evaluate_polynomial(C9, z);
 
-   static const T C10[] = {
+   BOOST_MATH_STATIC const T C10[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.00133244544948006563713),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.0019144384985654775265),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.00110893691345966373396),
    };
    workspace[10] = tools::evaluate_polynomial(C10, z);
 
-   static const T C11[] = {
+   BOOST_MATH_STATIC const T C11[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.00157972766073083495909),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.000162516262783915816899),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.00206334210355432762645),
@@ -263,7 +269,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[11] = tools::evaluate_polynomial(C11, z);
 
-   static const T C12[] = {
+   BOOST_MATH_STATIC const T C12[] = {
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.00407251211951401664727),
       BOOST_MATH_BIG_CONSTANT(T, 64, 0.00640336283380806979482),
       BOOST_MATH_BIG_CONSTANT(T, 64, -0.00404101610816766177474),
@@ -284,7 +290,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
 // (IEEE double precision or 10^-17).
 //
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<int, 53>&)
+BOOST_MATH_GPU_ENABLED T igamma_temme_large(T a, T x, const Policy& pol, const boost::math::integral_constant<int, 53>&)
 {
    BOOST_MATH_STD_USING // ADL of std functions
    T sigma = (x - a) / a;
@@ -426,7 +432,7 @@ BOOST_MATH_GPU_ENABLED T igamma_temme_large(T a, T x, const Policy& pol, const s
 // (IEEE float precision, or 10^-8)
 //
 template <class T, class Policy>
-BOOST_MATH_GPU_ENABLED T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<int, 24>&)
+BOOST_MATH_GPU_ENABLED T igamma_temme_large(T a, T x, const Policy& pol, const boost::math::integral_constant<int, 24>&)
 {
    BOOST_MATH_STD_USING // ADL of std functions
    T sigma = (x - a) / a;
@@ -482,7 +488,7 @@ BOOST_MATH_GPU_ENABLED T igamma_temme_large(T a, T x, const Policy& pol, const s
 // require many more terms in the polynomials.
 //
 template <class T, class Policy>
-T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<int, 113>&)
+BOOST_MATH_GPU_ENABLED T igamma_temme_large(T a, T x, const Policy& pol, const boost::math::integral_constant<int, 113>&)
 {
    BOOST_MATH_STD_USING // ADL of std functions
    T sigma = (x - a) / a;
@@ -494,7 +500,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
 
    T workspace[14];
 
-   static const T C0[] = {
+   BOOST_MATH_STATIC const T C0[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.333333333333333333333333333333333333),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.0833333333333333333333333333333333333),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.0148148148148148148148148148148148148),
@@ -529,7 +535,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[0] = tools::evaluate_polynomial(C0, z);
 
-   static const T C1[] = {
+   BOOST_MATH_STATIC const T C1[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.00185185185185185185185185185185185185),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.00347222222222222222222222222222222222),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.0026455026455026455026455026455026455),
@@ -562,7 +568,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[1] = tools::evaluate_polynomial(C1, z);
 
-   static const T C2[] = {
+   BOOST_MATH_STATIC const T C2[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.0041335978835978835978835978835978836),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.00268132716049382716049382716049382716),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.000771604938271604938271604938271604938),
@@ -593,7 +599,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[2] = tools::evaluate_polynomial(C2, z);
 
-   static const T C3[] = {
+   BOOST_MATH_STATIC const T C3[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.000649434156378600823045267489711934156),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.000229472093621399176954732510288065844),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.000469189494395255712128140111679206329),
@@ -622,7 +628,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[3] = tools::evaluate_polynomial(C3, z);
 
-   static const T C4[] = {
+   BOOST_MATH_STATIC const T C4[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.000861888290916711698604702719929057378),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.00078403922172006662747403488144228885),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.000299072480303190179733389609932819809),
@@ -649,7 +655,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[4] = tools::evaluate_polynomial(C4, z);
 
-   static const T C5[] = {
+   BOOST_MATH_STATIC const T C5[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.000336798553366358150308767592718210002),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.697281375836585777429398828575783308e-4),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.00027727532449593920787336425196507501),
@@ -670,7 +676,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[5] = tools::evaluate_polynomial(C5, z);
 
-   static const T C6[] = {
+   BOOST_MATH_STATIC const T C6[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.00053130793646399222316574854297762391),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.000592166437353693882864836225604401187),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.000270878209671804482771279183488328692),
@@ -689,7 +695,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[6] = tools::evaluate_polynomial(C6, z);
 
-   static const T C7[] = {
+   BOOST_MATH_STATIC const T C7[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.000344367606892377671254279625108523655),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.517179090826059219337057843002058823e-4),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.000334931610811422363116635090580012327),
@@ -706,7 +712,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[7] = tools::evaluate_polynomial(C7, z);
 
-   static const T C8[] = {
+   BOOST_MATH_STATIC const T C8[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.000652623918595309418922034919726622692),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.000839498720672087279993357516764983445),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.000438297098541721005061087953050560377),
@@ -721,7 +727,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[8] = tools::evaluate_polynomial(C8, z);
 
-   static const T C9[] = {
+   BOOST_MATH_STATIC const T C9[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.000596761290192746250124390067179459605),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.720489541602001055908571930225015052e-4),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.000678230883766732836161951166000673426),
@@ -734,7 +740,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[9] = tools::evaluate_polynomial(C9, z);
 
-   static const T C10[] = {
+   BOOST_MATH_STATIC const T C10[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.00133244544948006563712694993432717968),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.00191443849856547752650089885832852254),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.0011089369134596637339607446329267522),
@@ -745,7 +751,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[10] = tools::evaluate_polynomial(C10, z);
 
-   static const T C11[] = {
+   BOOST_MATH_STATIC const T C11[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.00157972766073083495908785631307733022),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.000162516262783915816898635123980270998),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.00206334210355432762645284467690276817),
@@ -754,7 +760,7 @@ T igamma_temme_large(T a, T x, const Policy& pol, const std::integral_constant<i
    };
    workspace[11] = tools::evaluate_polynomial(C11, z);
 
-   static const T C12[] = {
+   BOOST_MATH_STATIC const T C12[] = {
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.00407251211951401664727281097914544601),
       BOOST_MATH_BIG_CONSTANT(T, 113, 0.00640336283380806979482363809026579583),
       BOOST_MATH_BIG_CONSTANT(T, 113, -0.00404101610816766177473974858518094879),

--- a/include/boost/math/special_functions/detail/lgamma_small.hpp
+++ b/include/boost/math/special_functions/detail/lgamma_small.hpp
@@ -13,6 +13,9 @@
 
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/big_constant.hpp>
+#include <boost/math/tools/type_traits.hpp>
+#include <boost/math/tools/precision.hpp>
+#include <boost/math/special_functions/lanczos.hpp>
 
 #if defined(__GNUC__) && defined(BOOST_MATH_USE_FLOAT128)
 //
@@ -38,7 +41,7 @@ T gamma_imp(T z, const Policy& pol, const lanczos::undefined_lanczos& l);
 // lgamma for small arguments:
 //
 template <class T, class Policy, class Lanczos>
-BOOST_MATH_GPU_ENABLED T lgamma_small_imp(T z, T zm1, T zm2, const std::integral_constant<int, 64>&, const Policy& /* l */, const Lanczos&)
+BOOST_MATH_GPU_ENABLED T lgamma_small_imp(T z, T zm1, T zm2, const boost::math::integral_constant<int, 64>&, const Policy& /* l */, const Lanczos&)
 {
    // This version uses rational approximations for small
    // values of z accurate enough for 64-bit mantissas
@@ -227,7 +230,7 @@ BOOST_MATH_GPU_ENABLED T lgamma_small_imp(T z, T zm1, T zm2, const std::integral
    return result;
 }
 template <class T, class Policy, class Lanczos>
-T lgamma_small_imp(T z, T zm1, T zm2, const std::integral_constant<int, 113>&, const Policy& /* l */, const Lanczos&)
+T lgamma_small_imp(T z, T zm1, T zm2, const boost::math::integral_constant<int, 113>&, const Policy& /* l */, const Lanczos&)
 {
    //
    // This version uses rational approximations for small
@@ -484,7 +487,7 @@ T lgamma_small_imp(T z, T zm1, T zm2, const std::integral_constant<int, 113>&, c
    return result;
 }
 template <class T, class Policy, class Lanczos>
-T lgamma_small_imp(T z, T zm1, T zm2, const std::integral_constant<int, 0>&, const Policy& pol, const Lanczos& l)
+T lgamma_small_imp(T z, T zm1, T zm2, const boost::math::integral_constant<int, 0>&, const Policy& pol, const Lanczos& l)
 {
    //
    // No rational approximations are available because either

--- a/include/boost/math/special_functions/detail/unchecked_bernoulli.hpp
+++ b/include/boost/math/special_functions/detail/unchecked_bernoulli.hpp
@@ -209,7 +209,7 @@ namespace detail {
 #else // GPU Handling
 
    template <class T>
-   inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(boost::math::size_t n, const boost::math::integral_constant<int, 0>&)
+   BOOST_MATH_GPU_ENABLED inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(boost::math::size_t n, const boost::math::integral_constant<int, 0>&)
    {
       constexpr std::int64_t numerators[] = {
          boost::math::int64_t(+1LL),
@@ -393,7 +393,7 @@ namespace detail {
          -2.13999492572253336658107447651910973926742e34F,
          +2.05009757234780975699217330956723102516667e36F,
          -2.09380059113463784090951852900279701847092e38F,
-      }
+      };
 
       return bernoulli_data[n];
    }
@@ -690,10 +690,10 @@ namespace detail {
       return unchecked_bernoulli_data<T, 2>::bernoulli_data[n];
    }
 
-#else 
+#else // GPU Support
 
    template <class T>
-   inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(boost::math::size_t n, const boost::math::integral_constant<int, 2>&)
+   BOOST_MATH_GPU_ENABLED inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(boost::math::size_t n, const boost::math::integral_constant<int, 2>&)
    {
       constexpr double bernoulli_data[] = {
          +1.00000000000000000000000000000000000000000,

--- a/include/boost/math/special_functions/detail/unchecked_bernoulli.hpp
+++ b/include/boost/math/special_functions/detail/unchecked_bernoulli.hpp
@@ -4,6 +4,7 @@
 //  Copyright 2013 Christopher Kormanyos
 //  Copyright 2013 John Maddock
 //  Copyright 2013 Paul Bristow
+//  Copyright 2024 Matt Borland
 //  Distributed under the Boost
 //  Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -11,11 +12,11 @@
 #ifndef BOOST_MATH_UNCHECKED_BERNOULLI_HPP
 #define BOOST_MATH_UNCHECKED_BERNOULLI_HPP
 
-#include <limits>
-#include <type_traits>
-#include <array>
-#include <cmath>
-#include <cstdint>
+#include <boost/math/tools/config.hpp>
+#include <boost/math/tools/numeric_limits.hpp>
+#include <boost/math/tools/type_traits.hpp>
+#include <boost/math/tools/cstdint.hpp>
+#include <boost/math/tools/array.hpp>
 #include <boost/math/policies/error_handling.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/math_fwd.hpp>
@@ -58,20 +59,20 @@ template <class T>
 struct bernoulli_imp_variant
 {
    static constexpr unsigned value = 
-      (std::numeric_limits<T>::max_exponent == 128)
-      && (std::numeric_limits<T>::radix == 2)
-      && (std::numeric_limits<T>::digits <= std::numeric_limits<float>::digits)
-      && (std::is_convertible<float, T>::value) ? 1 :
+      (boost::math::numeric_limits<T>::max_exponent == 128)
+      && (boost::math::numeric_limits<T>::radix == 2)
+      && (boost::math::numeric_limits<T>::digits <= boost::math::numeric_limits<float>::digits)
+      && (boost::math::is_convertible<float, T>::value) ? 1 :
       (
-         (std::numeric_limits<T>::max_exponent == 1024)
-         && (std::numeric_limits<T>::radix == 2)
-         && (std::numeric_limits<T>::digits <= std::numeric_limits<double>::digits)
-         && (std::is_convertible<double, T>::value) ? 2 :
+         (boost::math::numeric_limits<T>::max_exponent == 1024)
+         && (boost::math::numeric_limits<T>::radix == 2)
+         && (boost::math::numeric_limits<T>::digits <= boost::math::numeric_limits<double>::digits)
+         && (boost::math::is_convertible<double, T>::value) ? 2 :
          (
-            (std::numeric_limits<T>::max_exponent == 16384)
-            && (std::numeric_limits<T>::radix == 2)
-            && (std::numeric_limits<T>::digits <= std::numeric_limits<long double>::digits)
-            && (std::is_convertible<long double, T>::value) ? 3 : (!std::is_convertible<std::int64_t, T>::value ? 4 : 0)
+            (boost::math::numeric_limits<T>::max_exponent == 16384)
+            && (boost::math::numeric_limits<T>::radix == 2)
+            && (boost::math::numeric_limits<T>::digits <= boost::math::numeric_limits<long double>::digits)
+            && (boost::math::is_convertible<long double, T>::value) ? 3 : (!boost::math::is_convertible<boost::math::int64_t, T>::value ? 4 : 0)
          )
       );
 };
@@ -82,9 +83,13 @@ template <class T>
 struct max_bernoulli_b2n : public detail::max_bernoulli_index<detail::bernoulli_imp_variant<T>::value>{};
 
 namespace detail {
+
+#ifndef BOOST_MATH_HAS_GPU_SUPPORT
+
    //
    // See https://github.com/boostorg/math/issues/923
    // for rationale behind using struct's here for constexpr data.
+   // Since we cannot use structs of static data on GPU we have to use slower method.
    //
    template <class T, int>
    struct unchecked_bernoulli_data;
@@ -93,119 +98,173 @@ namespace detail {
    struct unchecked_bernoulli_data<T, 0>
    {
 #ifdef BOOST_MATH_HAVE_CONSTEXPR_TABLES
-      static constexpr std::array<std::int64_t, 1 + max_bernoulli_b2n<T>::value> numerators =
+      static constexpr boost::math::array<boost::math::int64_t, 1 + max_bernoulli_b2n<T>::value> numerators =
       { {
-         std::int64_t(+1LL),
-         std::int64_t(+1LL),
-         std::int64_t(-1LL),
-         std::int64_t(+1LL),
-         std::int64_t(-1LL),
-         std::int64_t(+5LL),
-         std::int64_t(-691LL),
-         std::int64_t(+7LL),
-         std::int64_t(-3617LL),
-         std::int64_t(+43867LL),
-         std::int64_t(-174611LL),
-         std::int64_t(+854513LL),
-         std::int64_t(-236364091LL),
-         std::int64_t(+8553103LL),
-         std::int64_t(-23749461029LL),
-         std::int64_t(+8615841276005LL),
-         std::int64_t(-7709321041217LL),
-         std::int64_t(+2577687858367LL)
+         boost::math::int64_t(+1LL),
+         boost::math::int64_t(+1LL),
+         boost::math::int64_t(-1LL),
+         boost::math::int64_t(+1LL),
+         boost::math::int64_t(-1LL),
+         boost::math::int64_t(+5LL),
+         boost::math::int64_t(-691LL),
+         boost::math::int64_t(+7LL),
+         boost::math::int64_t(-3617LL),
+         boost::math::int64_t(+43867LL),
+         boost::math::int64_t(-174611LL),
+         boost::math::int64_t(+854513LL),
+         boost::math::int64_t(-236364091LL),
+         boost::math::int64_t(+8553103LL),
+         boost::math::int64_t(-23749461029LL),
+         boost::math::int64_t(+8615841276005LL),
+         boost::math::int64_t(-7709321041217LL),
+         boost::math::int64_t(+2577687858367LL)
       } };
 
-      static constexpr std::array<std::int64_t, 1 + max_bernoulli_b2n<T>::value> denominators =
+      static constexpr boost::math::array<boost::math::int64_t, 1 + max_bernoulli_b2n<T>::value> denominators =
       { {
-         std::int64_t(1LL),
-         std::int64_t(6LL),
-         std::int64_t(30LL),
-         std::int64_t(42LL),
-         std::int64_t(30LL),
-         std::int64_t(66LL),
-         std::int64_t(2730LL),
-         std::int64_t(6LL),
-         std::int64_t(510LL),
-         std::int64_t(798LL),
-         std::int64_t(330LL),
-         std::int64_t(138LL),
-         std::int64_t(2730LL),
-         std::int64_t(6LL),
-         std::int64_t(870LL),
-         std::int64_t(14322LL),
-         std::int64_t(510LL),
-         std::int64_t(6LL)
+         boost::math::int64_t(1LL),
+         boost::math::int64_t(6LL),
+         boost::math::int64_t(30LL),
+         boost::math::int64_t(42LL),
+         boost::math::int64_t(30LL),
+         boost::math::int64_t(66LL),
+         boost::math::int64_t(2730LL),
+         boost::math::int64_t(6LL),
+         boost::math::int64_t(510LL),
+         boost::math::int64_t(798LL),
+         boost::math::int64_t(330LL),
+         boost::math::int64_t(138LL),
+         boost::math::int64_t(2730LL),
+         boost::math::int64_t(6LL),
+         boost::math::int64_t(870LL),
+         boost::math::int64_t(14322LL),
+         boost::math::int64_t(510LL),
+         boost::math::int64_t(6LL)
       } };
 #else
-      static const std::array<std::int64_t, 1 + max_bernoulli_b2n<T>::value> denominators;
-      static const std::array<std::int64_t, 1 + max_bernoulli_b2n<T>::value> numerators;
+      static const boost::math::array<boost::math::int64_t, 1 + max_bernoulli_b2n<T>::value> denominators;
+      static const boost::math::array<boost::math::int64_t, 1 + max_bernoulli_b2n<T>::value> numerators;
 #endif
    };
 
 #ifdef BOOST_MATH_HAVE_CONSTEXPR_TABLES
    template <class T>
-   constexpr std::array<std::int64_t, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 0>::numerators;
+   constexpr boost::math::array<boost::math::int64_t, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 0>::numerators;
    template <class T>
-   constexpr std::array<std::int64_t, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 0>::denominators;
+   constexpr boost::math::array<boost::math::int64_t, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 0>::denominators;
 #else
    template <class T>
-   const std::array<std::int64_t, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 0>::numerators =
+   const boost::math::array<boost::math::int64_t, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 0>::numerators =
    { {
-      std::int64_t(+1LL),
-      std::int64_t(+1LL),
-      std::int64_t(-1LL),
-      std::int64_t(+1LL),
-      std::int64_t(-1LL),
-      std::int64_t(+5LL),
-      std::int64_t(-691LL),
-      std::int64_t(+7LL),
-      std::int64_t(-3617LL),
-      std::int64_t(+43867LL),
-      std::int64_t(-174611LL),
-      std::int64_t(+854513LL),
-      std::int64_t(-236364091LL),
-      std::int64_t(+8553103LL),
-      std::int64_t(-23749461029LL),
-      std::int64_t(+8615841276005LL),
-      std::int64_t(-7709321041217LL),
-      std::int64_t(+2577687858367LL)
+      boost::math::int64_t(+1LL),
+      boost::math::int64_t(+1LL),
+      boost::math::int64_t(-1LL),
+      boost::math::int64_t(+1LL),
+      boost::math::int64_t(-1LL),
+      boost::math::int64_t(+5LL),
+      boost::math::int64_t(-691LL),
+      boost::math::int64_t(+7LL),
+      boost::math::int64_t(-3617LL),
+      boost::math::int64_t(+43867LL),
+      boost::math::int64_t(-174611LL),
+      boost::math::int64_t(+854513LL),
+      boost::math::int64_t(-236364091LL),
+      boost::math::int64_t(+8553103LL),
+      boost::math::int64_t(-23749461029LL),
+      boost::math::int64_t(+8615841276005LL),
+      boost::math::int64_t(-7709321041217LL),
+      boost::math::int64_t(+2577687858367LL)
    } };
 
    template <class T>
-   const std::array<std::int64_t, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 0>::denominators =
+   const boost::math::array<boost::math::int64_t, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 0>::denominators =
    { {
-      std::int64_t(1LL),
-      std::int64_t(6LL),
-      std::int64_t(30LL),
-      std::int64_t(42LL),
-      std::int64_t(30LL),
-      std::int64_t(66LL),
-      std::int64_t(2730LL),
-      std::int64_t(6LL),
-      std::int64_t(510LL),
-      std::int64_t(798LL),
-      std::int64_t(330LL),
-      std::int64_t(138LL),
-      std::int64_t(2730LL),
-      std::int64_t(6LL),
-      std::int64_t(870LL),
-      std::int64_t(14322LL),
-      std::int64_t(510LL),
-      std::int64_t(6LL)
+      boost::math::int64_t(1LL),
+      boost::math::int64_t(6LL),
+      boost::math::int64_t(30LL),
+      boost::math::int64_t(42LL),
+      boost::math::int64_t(30LL),
+      boost::math::int64_t(66LL),
+      boost::math::int64_t(2730LL),
+      boost::math::int64_t(6LL),
+      boost::math::int64_t(510LL),
+      boost::math::int64_t(798LL),
+      boost::math::int64_t(330LL),
+      boost::math::int64_t(138LL),
+      boost::math::int64_t(2730LL),
+      boost::math::int64_t(6LL),
+      boost::math::int64_t(870LL),
+      boost::math::int64_t(14322LL),
+      boost::math::int64_t(510LL),
+      boost::math::int64_t(6LL)
    } };
 #endif
 
    template <class T>
-   inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(std::size_t n, const std::integral_constant<int, 0>&)
+   inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(boost::math::size_t n, const boost::math::integral_constant<int, 0>&)
    {
       return T(unchecked_bernoulli_data<T, 0>::numerators[n]) / unchecked_bernoulli_data<T, 0>::denominators[n];
    }
+
+#else // GPU Handling
+
+   template <class T>
+   inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(boost::math::size_t n, const boost::math::integral_constant<int, 0>&)
+   {
+      constexpr std::int64_t numerators[] = {
+         boost::math::int64_t(+1LL),
+         boost::math::int64_t(+1LL),
+         boost::math::int64_t(-1LL),
+         boost::math::int64_t(+1LL),
+         boost::math::int64_t(-1LL),
+         boost::math::int64_t(+5LL),
+         boost::math::int64_t(-691LL),
+         boost::math::int64_t(+7LL),
+         boost::math::int64_t(-3617LL),
+         boost::math::int64_t(+43867LL),
+         boost::math::int64_t(-174611LL),
+         boost::math::int64_t(+854513LL),
+         boost::math::int64_t(-236364091LL),
+         boost::math::int64_t(+8553103LL),
+         boost::math::int64_t(-23749461029LL),
+         boost::math::int64_t(+8615841276005LL),
+         boost::math::int64_t(-7709321041217LL),
+         boost::math::int64_t(+2577687858367LL)
+      };
+
+      constexpr std::int64_t denominators[] = {
+         boost::math::int64_t(1LL),
+         boost::math::int64_t(6LL),
+         boost::math::int64_t(30LL),
+         boost::math::int64_t(42LL),
+         boost::math::int64_t(30LL),
+         boost::math::int64_t(66LL),
+         boost::math::int64_t(2730LL),
+         boost::math::int64_t(6LL),
+         boost::math::int64_t(510LL),
+         boost::math::int64_t(798LL),
+         boost::math::int64_t(330LL),
+         boost::math::int64_t(138LL),
+         boost::math::int64_t(2730LL),
+         boost::math::int64_t(6LL),
+         boost::math::int64_t(870LL),
+         boost::math::int64_t(14322LL),
+         boost::math::int64_t(510LL),
+         boost::math::int64_t(6LL)
+      };
+
+      return T(numerators[n]) / denominators[n];
+   }
+
+#endif // BOOST_MATH_HAS_GPU_SUPPORT
+
+#ifndef BOOST_MATH_HAS_GPU_SUPPORT
 
    template <class T>
    struct unchecked_bernoulli_data<T, 1>
    {
 #ifdef BOOST_MATH_HAVE_CONSTEXPR_TABLES
-      static constexpr std::array<float, 1 + max_bernoulli_b2n<T>::value> bernoulli_data =
+      static constexpr boost::math::array<float, 1 + max_bernoulli_b2n<T>::value> bernoulli_data =
       { {
          +1.00000000000000000000000000000000000000000F,
          +0.166666666666666666666666666666666666666667F,
@@ -242,16 +301,16 @@ namespace detail {
          -2.09380059113463784090951852900279701847092e38F,
       } };
 #else
-      static const std::array<float, 1 + max_bernoulli_b2n<T>::value> bernoulli_data;
+      static const boost::math::array<float, 1 + max_bernoulli_b2n<T>::value> bernoulli_data;
 #endif
    };
 
 #ifdef BOOST_MATH_HAVE_CONSTEXPR_TABLES
    template <class T>
-   constexpr std::array<float, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 1>::bernoulli_data;
+   constexpr boost::math::array<float, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 1>::bernoulli_data;
 #else
    template <class T>
-   const std::array<float, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 1>::bernoulli_data =
+   const boost::math::array<float, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 1>::bernoulli_data =
    { {
       +1.00000000000000000000000000000000000000000F,
       +0.166666666666666666666666666666666666666667F,
@@ -290,16 +349,64 @@ namespace detail {
 #endif
 
    template <class T>
-   inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(std::size_t n, const std::integral_constant<int, 1>&)
+   inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(boost::math::size_t n, const boost::math::integral_constant<int, 1>&)
    {
       return unchecked_bernoulli_data<T, 1>::bernoulli_data[n];
    }
+
+#else
+
+   template <class T>
+   BOOST_MATH_GPU_ENABLED inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(boost::math::size_t n, const boost::math::integral_constant<int, 1>&)
+   {
+      constexpr float bernoulli_data[] = {
+         +1.00000000000000000000000000000000000000000F,
+         +0.166666666666666666666666666666666666666667F,
+         -0.0333333333333333333333333333333333333333333F,
+         +0.0238095238095238095238095238095238095238095F,
+         -0.0333333333333333333333333333333333333333333F,
+         +0.0757575757575757575757575757575757575757576F,
+         -0.253113553113553113553113553113553113553114F,
+         +1.16666666666666666666666666666666666666667F,
+         -7.09215686274509803921568627450980392156863F,
+         +54.9711779448621553884711779448621553884712F,
+         -529.124242424242424242424242424242424242424F,
+         +6192.12318840579710144927536231884057971014F,
+         -86580.2531135531135531135531135531135531136F,
+         +1.42551716666666666666666666666666666666667e6F,
+         -2.72982310678160919540229885057471264367816e7F,
+         +6.01580873900642368384303868174835916771401e8F,
+         -1.51163157670921568627450980392156862745098e10F,
+         +4.29614643061166666666666666666666666666667e11F,
+         -1.37116552050883327721590879485616327721591e13F,
+         +4.88332318973593166666666666666666666666667e14F,
+         -1.92965793419400681486326681448632668144863e16F,
+         +8.41693047573682615000553709856035437430786e17F,
+         -4.03380718540594554130768115942028985507246e19F,
+         +2.11507486380819916056014539007092198581560e21F,
+         -1.20866265222965259346027311937082525317819e23F,
+         +7.50086674607696436685572007575757575757576e24F,
+         -5.03877810148106891413789303052201257861635e26F,
+         +3.65287764848181233351104308429711779448622e28F,
+         -2.84987693024508822262691464329106781609195e30F,
+         +2.38654274996836276446459819192192149717514e32F,
+         -2.13999492572253336658107447651910973926742e34F,
+         +2.05009757234780975699217330956723102516667e36F,
+         -2.09380059113463784090951852900279701847092e38F,
+      }
+
+      return bernoulli_data[n];
+   }
+
+#endif // BOOST_MATH_HAS_GPU_SUPPORT
+
+#ifndef BOOST_MATH_HAS_GPU_SUPPORT
 
    template <class T>
    struct unchecked_bernoulli_data<T, 2>
    {
 #ifdef BOOST_MATH_HAVE_CONSTEXPR_TABLES
-      static constexpr std::array<double, 1 + max_bernoulli_b2n<T>::value> bernoulli_data =
+      static constexpr boost::math::array<double, 1 + max_bernoulli_b2n<T>::value> bernoulli_data =
       { {
          +1.00000000000000000000000000000000000000000,
          +0.166666666666666666666666666666666666666667,
@@ -433,16 +540,16 @@ namespace detail {
          +1.33527841873546338750122832017820518292039e306
       } };
 #else
-      static const std::array<double, 1 + max_bernoulli_b2n<T>::value> bernoulli_data;
+      static const boost::math::array<double, 1 + max_bernoulli_b2n<T>::value> bernoulli_data;
 #endif
    };
 
 #ifdef BOOST_MATH_HAVE_CONSTEXPR_TABLES
    template <class T>
-   constexpr const std::array<double, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 2>::bernoulli_data;
+   constexpr const boost::math::array<double, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 2>::bernoulli_data;
 #else
    template <class T>
-   const std::array<double, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 2>::bernoulli_data =
+   const boost::math::array<double, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 2>::bernoulli_data =
    { {
       +1.00000000000000000000000000000000000000000,
       +0.166666666666666666666666666666666666666667,
@@ -578,16 +685,163 @@ namespace detail {
 #endif
 
    template <class T>
-   inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(std::size_t n, const std::integral_constant<int, 2>&)
+   inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(boost::math::size_t n, const boost::math::integral_constant<int, 2>&)
    {
       return unchecked_bernoulli_data<T, 2>::bernoulli_data[n];
    }
+
+#else 
+
+   template <class T>
+   inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(boost::math::size_t n, const boost::math::integral_constant<int, 2>&)
+   {
+      constexpr double bernoulli_data[] = {
+         +1.00000000000000000000000000000000000000000,
+         +0.166666666666666666666666666666666666666667,
+         -0.0333333333333333333333333333333333333333333,
+         +0.0238095238095238095238095238095238095238095,
+         -0.0333333333333333333333333333333333333333333,
+         +0.0757575757575757575757575757575757575757576,
+         -0.253113553113553113553113553113553113553114,
+         +1.16666666666666666666666666666666666666667,
+         -7.09215686274509803921568627450980392156863,
+         +54.9711779448621553884711779448621553884712,
+         -529.124242424242424242424242424242424242424,
+         +6192.12318840579710144927536231884057971014,
+         -86580.2531135531135531135531135531135531136,
+         +1.42551716666666666666666666666666666666667e6,
+         -2.72982310678160919540229885057471264367816e7,
+         +6.01580873900642368384303868174835916771401e8,
+         -1.51163157670921568627450980392156862745098e10,
+         +4.29614643061166666666666666666666666666667e11,
+         -1.37116552050883327721590879485616327721591e13,
+         +4.88332318973593166666666666666666666666667e14,
+         -1.92965793419400681486326681448632668144863e16,
+         +8.41693047573682615000553709856035437430786e17,
+         -4.03380718540594554130768115942028985507246e19,
+         +2.11507486380819916056014539007092198581560e21,
+         -1.20866265222965259346027311937082525317819e23,
+         +7.50086674607696436685572007575757575757576e24,
+         -5.03877810148106891413789303052201257861635e26,
+         +3.65287764848181233351104308429711779448622e28,
+         -2.84987693024508822262691464329106781609195e30,
+         +2.38654274996836276446459819192192149717514e32,
+         -2.13999492572253336658107447651910973926742e34,
+         +2.05009757234780975699217330956723102516667e36,
+         -2.09380059113463784090951852900279701847092e38,
+         +2.27526964884635155596492603527692645814700e40,
+         -2.62577102862395760473030497361582020814490e42,
+         +3.21250821027180325182047923042649852435219e44,
+         -4.15982781667947109139170744952623589366896e46,
+         +5.69206954820352800238834562191210586444805e48,
+         -8.21836294197845756922906534686173330145509e50,
+         +1.25029043271669930167323398297028955241772e53,
+         -2.00155832332483702749253291988132987687242e55,
+         +3.36749829153643742333966769033387530162196e57,
+         -5.94709705031354477186604968440515408405791e59,
+         +1.10119103236279775595641307904376916046305e62,
+         -2.13552595452535011886583850190410656789733e64,
+         +4.33288969866411924196166130593792062184514e66,
+         -9.18855282416693282262005552155018971389604e68,
+         +2.03468967763290744934550279902200200659751e71,
+         -4.70038339580357310785752555350060606545967e73,
+         +1.13180434454842492706751862577339342678904e76,
+         -2.83822495706937069592641563364817647382847e78,
+         +7.40642489796788506297508271409209841768797e80,
+         -2.00964548027566044834656196727153631868673e83,
+         +5.66571700508059414457193460305193569614195e85,
+         -1.65845111541362169158237133743199123014950e88,
+         +5.03688599504923774192894219151801548124424e90,
+         -1.58614682376581863693634015729664387827410e93,
+         +5.17567436175456269840732406825071225612408e95,
+         -1.74889218402171173396900258776181591451415e98,
+         +6.11605199949521852558245252642641677807677e100,
+         -2.21227769127078349422883234567129324455732e103,
+         +8.27227767987709698542210624599845957312047e105,
+         -3.19589251114157095835916343691808148735263e108,
+         +1.27500822233877929823100243029266798669572e111,
+         -5.25009230867741338994028246245651754469199e113,
+         +2.23018178942416252098692981988387281437383e116,
+         -9.76845219309552044386335133989802393011669e118,
+         +4.40983619784529542722726228748131691918758e121,
+         -2.05085708864640888397293377275830154864566e124,
+         +9.82144332797912771075729696020975210414919e126,
+         -4.84126007982088805087891967099634127611305e129,
+         +2.45530888014809826097834674040886903996737e132,
+         -1.28069268040847475487825132786017857218118e135,
+         +6.86761671046685811921018885984644004360924e137,
+         -3.78464685819691046949789954163795568144895e140,
+         +2.14261012506652915508713231351482720966602e143,
+         -1.24567271371836950070196429616376072194583e146,
+         +7.43457875510001525436796683940520613117807e148,
+         -4.55357953046417048940633332233212748767721e151,
+         +2.86121128168588683453638472510172325229190e154,
+         -1.84377235520338697276882026536287854875414e157,
+         +1.21811545362210466995013165065995213558174e160,
+         -8.24821871853141215484818457296893447301419e162,
+         +5.72258779378329433296516498142978615918685e165,
+         -4.06685305250591047267679693831158655602196e168,
+         +2.95960920646420500628752695815851870426379e171,
+         -2.20495225651894575090311752273445984836379e174,
+         +1.68125970728895998058311525151360665754464e177,
+         -1.31167362135569576486452806355817153004431e180,
+         +1.04678940094780380821832853929823089643829e183,
+         -8.54328935788337077185982546299082774593270e185,
+         +7.12878213224865423522884066771438224721245e188,
+         -6.08029314555358993000847118686477458461988e191,
+         +5.29967764248499239300942910043247266228490e194,
+         -4.71942591687458626443646229013379911103761e197,
+         +4.29284137914029810894168296541074669045521e200,
+         -3.98767449682322074434477655542938795106651e203,
+         +3.78197804193588827138944181161393327898220e206,
+         -3.66142336836811912436858082151197348755196e209,
+         +3.61760902723728623488554609298914089477541e212,
+         -3.64707726451913543621383088655499449048682e215,
+         +3.75087554364544090983452410104814189306842e218,
+         -3.93458672964390282694891288533713429355657e221,
+         +4.20882111481900820046571171111494898242731e224,
+         -4.59022962206179186559802940573325591059371e227,
+         +5.10317257726295759279198185106496768539760e230,
+         -5.78227623036569554015377271242917142512200e233,
+         +6.67624821678358810322637794412809363451080e236,
+         -7.85353076444504163225916259639312444428230e239,
+         +9.41068940670587255245443288258762485293948e242,
+         -1.14849338734651839938498599206805592548354e246,
+         +1.42729587428487856771416320087122499897180e249,
+         -1.80595595869093090142285728117654560926719e252,
+         +2.32615353076608052161297985184708876161736e255,
+         -3.04957517154995947681942819261542593785327e258,
+         +4.06858060764339734424012124124937318633684e261,
+         -5.52310313219743616252320044093186392324280e264,
+         +7.62772793964343924869949690204961215533859e267,
+         -1.07155711196978863132793524001065396932667e271,
+         +1.53102008959691884453440916153355334355847e274,
+         -2.22448916821798346676602348865048510824835e277,
+         +3.28626791906901391668189736436895275365183e280,
+         -4.93559289559603449020711938191575963496999e283,
+         +7.53495712008325067212266049779283956727824e286,
+         -1.16914851545841777278088924731655041783900e290,
+         +1.84352614678389394126646201597702232396492e293,
+         -2.95368261729680829728014917350525183485207e296,
+         +4.80793212775015697668878704043264072227967e299,
+         -7.95021250458852528538243631671158693036798e302,
+         +1.33527841873546338750122832017820518292039e306
+      };
+
+      return bernoulli_data[n];
+   }
+
+#endif // BOOST_MATH_HAS_GPU_SUPPORT
+
+
+// Only need float and double on device
+#ifndef BOOST_MATH_HAS_GPU_SUPPORT
 
    template <class T>
    struct unchecked_bernoulli_data<T, 3>
    {
 #ifdef BOOST_MATH_HAVE_CONSTEXPR_TABLES
-   static constexpr std::array<long double, 1 + max_bernoulli_b2n<T>::value> bernoulli_data =
+   static constexpr boost::math::array<long double, 1 + max_bernoulli_b2n<T>::value> bernoulli_data =
    { {
       +1.00000000000000000000000000000000000000000L,
       +0.166666666666666666666666666666666666666667L,
@@ -910,16 +1164,16 @@ namespace detail {
    #endif
       } };
 #else
-      static const std::array<long double, 1 + max_bernoulli_b2n<T>::value> bernoulli_data;
+      static const boost::math::array<long double, 1 + max_bernoulli_b2n<T>::value> bernoulli_data;
 #endif
    };
 
 #ifdef BOOST_MATH_HAVE_CONSTEXPR_TABLES
    template <class T>
-   constexpr const std::array<long double, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 3>::bernoulli_data;
+   constexpr const boost::math::array<long double, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 3>::bernoulli_data;
 #else
    template <class T>
-   const std::array<long double, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 3>::bernoulli_data =
+   const boost::math::array<long double, 1 + max_bernoulli_b2n<T>::value> unchecked_bernoulli_data<T, 3>::bernoulli_data =
    { {
       +1.00000000000000000000000000000000000000000L,
       +0.166666666666666666666666666666666666666667L,
@@ -1244,58 +1498,60 @@ namespace detail {
 #endif
 
 template <class T>
-inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(std::size_t n, const std::integral_constant<int, 3>& )
+inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_imp(boost::math::size_t n, const boost::math::integral_constant<int, 3>& )
 {
    return unchecked_bernoulli_data<T, 3>::bernoulli_data[n];
 }
 
 template <class T>
-inline T unchecked_bernoulli_imp(std::size_t n, const std::integral_constant<int, 4>& )
+inline T unchecked_bernoulli_imp(boost::math::size_t n, const boost::math::integral_constant<int, 4>& )
 {
    //
    // Special case added for multiprecision types that have no conversion from long long,
    // there are very few such types, but mpfr_class is one.
    //
-   static const std::array<std::int32_t, 1 + max_bernoulli_b2n<T>::value> numerators =
+   static const boost::math::array<boost::math::int32_t, 1 + max_bernoulli_b2n<T>::value> numerators =
    {{
-      std::int32_t(            +1LL),
-      std::int32_t(            +1LL),
-      std::int32_t(            -1LL),
-      std::int32_t(            +1LL),
-      std::int32_t(            -1LL),
-      std::int32_t(            +5LL),
-      std::int32_t(          -691LL),
-      std::int32_t(            +7LL),
-      std::int32_t(         -3617LL),
-      std::int32_t(        +43867LL),
-      std::int32_t(       -174611LL),
-      std::int32_t(       +854513LL),
+      boost::math::int32_t(            +1LL),
+      boost::math::int32_t(            +1LL),
+      boost::math::int32_t(            -1LL),
+      boost::math::int32_t(            +1LL),
+      boost::math::int32_t(            -1LL),
+      boost::math::int32_t(            +5LL),
+      boost::math::int32_t(          -691LL),
+      boost::math::int32_t(            +7LL),
+      boost::math::int32_t(         -3617LL),
+      boost::math::int32_t(        +43867LL),
+      boost::math::int32_t(       -174611LL),
+      boost::math::int32_t(       +854513LL),
    }};
 
-   static const std::array<std::int32_t, 1 + max_bernoulli_b2n<T>::value> denominators =
+   static const boost::math::array<boost::math::int32_t, 1 + max_bernoulli_b2n<T>::value> denominators =
    {{
-      std::int32_t(      1LL),
-      std::int32_t(      6LL),
-      std::int32_t(     30LL),
-      std::int32_t(     42LL),
-      std::int32_t(     30LL),
-      std::int32_t(     66LL),
-      std::int32_t(   2730LL),
-      std::int32_t(      6LL),
-      std::int32_t(    510LL),
-      std::int32_t(    798LL),
-      std::int32_t(    330LL),
-      std::int32_t(    138LL),
+      boost::math::int32_t(      1LL),
+      boost::math::int32_t(      6LL),
+      boost::math::int32_t(     30LL),
+      boost::math::int32_t(     42LL),
+      boost::math::int32_t(     30LL),
+      boost::math::int32_t(     66LL),
+      boost::math::int32_t(   2730LL),
+      boost::math::int32_t(      6LL),
+      boost::math::int32_t(    510LL),
+      boost::math::int32_t(    798LL),
+      boost::math::int32_t(    330LL),
+      boost::math::int32_t(    138LL),
    }};
    return T(numerators[n]) / T(denominators[n]);
 }
 
+#endif // BOOST_MATH_HAS_GPU_SUPPORT
+
 } // namespace detail
 
 template<class T>
-inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_b2n(const std::size_t n)
+inline BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_b2n(const boost::math::size_t n)
 {
-   typedef std::integral_constant<int, detail::bernoulli_imp_variant<T>::value> tag_type;
+   typedef boost::math::integral_constant<int, detail::bernoulli_imp_variant<T>::value> tag_type;
 
    return detail::unchecked_bernoulli_imp<T>(n, tag_type());
 }

--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -15,9 +15,6 @@
 #endif
 
 #include <boost/math/tools/config.hpp>
-
-#ifndef BOOST_MATH_HAS_NVRTC
-
 #include <boost/math/tools/series.hpp>
 #include <boost/math/tools/fraction.hpp>
 #include <boost/math/tools/precision.hpp>
@@ -60,13 +57,13 @@ namespace boost{ namespace math{
 namespace detail{
 
 template <class T>
-BOOST_MATH_GPU_ENABLED inline bool is_odd(T v, const std::true_type&)
+BOOST_MATH_GPU_ENABLED inline bool is_odd(T v, const boost::math::true_type&)
 {
    int i = static_cast<int>(v);
    return i&1;
 }
 template <class T>
-BOOST_MATH_GPU_ENABLED inline bool is_odd(T v, const std::false_type&)
+BOOST_MATH_GPU_ENABLED inline bool is_odd(T v, const boost::math::false_type&)
 {
    // Oh dear can't cast T to int!
    BOOST_MATH_STD_USING
@@ -76,7 +73,7 @@ BOOST_MATH_GPU_ENABLED inline bool is_odd(T v, const std::false_type&)
 template <class T>
 BOOST_MATH_GPU_ENABLED inline bool is_odd(T v)
 {
-   return is_odd(v, ::std::is_convertible<T, int>());
+   return is_odd(v, ::boost::math::is_convertible<T, int>());
 }
 
 template <class T>
@@ -259,7 +256,7 @@ BOOST_MATH_GPU_ENABLED T lgamma_imp_final(T z, const Policy& pol, const Lanczos&
    else if(z < 15)
    {
       typedef typename policies::precision<T, Policy>::type precision_type;
-      typedef std::integral_constant<int,
+      typedef boost::math::integral_constant<int,
          precision_type::value <= 0 ? 0 :
          precision_type::value <= 64 ? 64 :
          precision_type::value <= 113 ? 113 : 0
@@ -267,7 +264,7 @@ BOOST_MATH_GPU_ENABLED T lgamma_imp_final(T z, const Policy& pol, const Lanczos&
 
       result = lgamma_small_imp<T>(z, T(z - 1), T(z - 2), tag_type(), pol, l);
    }
-   else if((z >= 3) && (z < 100) && (std::numeric_limits<T>::max_exponent >= 1024))
+   else if((z >= 3) && (z < 100) && (boost::math::numeric_limits<T>::max_exponent >= 1024))
    {
       // taking the log of tgamma reduces the error, no danger of overflow here:
       result = log(gamma_imp(z, pol, l));
@@ -349,7 +346,7 @@ private:
    T z, a;
    int k;
 public:
-   typedef std::pair<T,T> result_type;
+   typedef boost::math::pair<T,T> result_type;
 
    BOOST_MATH_GPU_ENABLED upper_incomplete_gamma_fract(T a1, T z1)
       : z(z1-a1+1), a(a1), k(0)
@@ -399,7 +396,7 @@ BOOST_MATH_GPU_ENABLED inline T lower_gamma_series(T a, T z, const Policy& pol, 
    // lower incomplete integral. Then divide by tgamma(a)
    // to get the normalised value.
    lower_incomplete_gamma_series<T> s(a, z);
-   std::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
+   boost::math::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
    T factor = policies::get_epsilon<T, Policy>();
    T result = boost::math::tools::sum_series(s, factor, max_iter, init_value);
    policies::check_series_iterations<T>("boost::math::detail::lower_gamma_series<%1%>(%1%)", max_iter, pol);
@@ -413,12 +410,12 @@ BOOST_MATH_GPU_ENABLED inline T lower_gamma_series(T a, T z, const Policy& pol, 
 template<class T>
 BOOST_MATH_GPU_ENABLED boost::math::size_t highest_bernoulli_index()
 {
-   const float digits10_of_type = (std::numeric_limits<T>::is_specialized
-                                      ? static_cast<float>(std::numeric_limits<T>::digits10)
+   const float digits10_of_type = (boost::math::numeric_limits<T>::is_specialized
+                                      ? static_cast<float>(boost::math::numeric_limits<T>::digits10)
                                       : static_cast<float>(boost::math::tools::digits<T>() * 0.301F));
 
    // Find the high index n for Bn to produce the desired precision in Stirling's calculation.
-   return static_cast<std::size_t>(18.0F + (0.6F * digits10_of_type));
+   return static_cast<boost::math::size_t>(18.0F + (0.6F * digits10_of_type));
 }
 
 template<class T>
@@ -426,8 +423,8 @@ BOOST_MATH_GPU_ENABLED int minimum_argument_for_bernoulli_recursion()
 {
    BOOST_MATH_STD_USING
 
-   const float digits10_of_type = (std::numeric_limits<T>::is_specialized
-                                    ? (float) std::numeric_limits<T>::digits10
+   const float digits10_of_type = (boost::math::numeric_limits<T>::is_specialized
+                                    ? (float) boost::math::numeric_limits<T>::digits10
                                     : (float) (boost::math::tools::digits<T>() * 0.301F));
 
    int min_arg = (int) (digits10_of_type * 1.7F);
@@ -449,7 +446,7 @@ BOOST_MATH_GPU_ENABLED int minimum_argument_for_bernoulli_recursion()
       const float d2_minus_one = ((digits10_of_type / 0.301F) - 1.0F);
       const float limit        = ceil(exp((d2_minus_one * log(2.0F)) / 20.0F));
 
-      min_arg = (int) ((std::min)(digits10_of_type * 1.7F, limit));
+      min_arg = (int) (BOOST_MATH_GPU_SAFE_MIN(digits10_of_type * 1.7F, limit));
    }
 
    return min_arg;
@@ -468,7 +465,7 @@ BOOST_MATH_GPU_ENABLED T scaled_tgamma_no_lanczos(const T& z, const Policy& pol,
 
    // Perform the Bernoulli series expansion of Stirling's approximation.
 
-   const std::size_t number_of_bernoullis_b2n = policies::get_max_series_iterations<Policy>();
+   const boost::math::size_t number_of_bernoullis_b2n = policies::get_max_series_iterations<Policy>();
 
    T one_over_x_pow_two_n_minus_one = 1 / z;
    const T one_over_x2 = one_over_x_pow_two_n_minus_one * one_over_x_pow_two_n_minus_one;
@@ -477,11 +474,11 @@ BOOST_MATH_GPU_ENABLED T scaled_tgamma_no_lanczos(const T& z, const Policy& pol,
    const T half_ln_two_pi_over_z = sqrt(boost::math::constants::two_pi<T>() / z);
    T last_term = 2 * sum;
 
-   for (std::size_t n = 2U;; ++n)
+   for (boost::math::size_t n = 2U;; ++n)
    {
       one_over_x_pow_two_n_minus_one *= one_over_x2;
 
-      const std::size_t n2 = static_cast<std::size_t>(n * 2U);
+      const boost::math::size_t n2 = static_cast<boost::math::size_t>(n * 2U);
 
       const T term = (boost::math::bernoulli_b2n<T>(static_cast<int>(n)) * one_over_x_pow_two_n_minus_one) / (n2 * (n2 - 1U));
 
@@ -786,7 +783,7 @@ BOOST_MATH_GPU_ENABLED T tgammap1m1_imp(T dz, Policy const& pol, const Lanczos& 
 
    typedef typename policies::precision<T,Policy>::type precision_type;
 
-   typedef std::integral_constant<int,
+   typedef boost::math::integral_constant<int,
       precision_type::value <= 0 ? 0 :
       precision_type::value <= 64 ? 64 :
       precision_type::value <= 113 ? 113 : 0
@@ -971,16 +968,16 @@ BOOST_MATH_GPU_ENABLED T regularised_gamma_prefix(T a, T z, const Policy& pol, c
       //
       T alz = a * log(z / agh);
       T amz = a - z;
-      if(((std::min)(alz, amz) <= tools::log_min_value<T>()) || ((std::max)(alz, amz) >= tools::log_max_value<T>()))
+      if((BOOST_MATH_GPU_SAFE_MIN(alz, amz) <= tools::log_min_value<T>()) || (BOOST_MATH_GPU_SAFE_MAX(alz, amz) >= tools::log_max_value<T>()))
       {
          T amza = amz / a;
-         if(((std::min)(alz, amz)/2 > tools::log_min_value<T>()) && ((std::max)(alz, amz)/2 < tools::log_max_value<T>()))
+         if((BOOST_MATH_GPU_SAFE_MIN(alz, amz)/2 > tools::log_min_value<T>()) && (BOOST_MATH_GPU_SAFE_MAX(alz, amz)/2 < tools::log_max_value<T>()))
          {
             // compute square root of the result and then square it:
             T sq = pow(z / agh, a / 2) * exp(amz / 2);
             prefix = sq * sq;
          }
-         else if(((std::min)(alz, amz)/4 > tools::log_min_value<T>()) && ((std::max)(alz, amz)/4 < tools::log_max_value<T>()) && (z > a))
+         else if((BOOST_MATH_GPU_SAFE_MIN(alz, amz)/4 > tools::log_min_value<T>()) && (BOOST_MATH_GPU_SAFE_MAX(alz, amz)/4 < tools::log_max_value<T>()) && (z > a))
          {
             // compute the 4th root of the result then square it twice:
             T sq = pow(z / agh, a / 4) * exp(amz / 4);
@@ -1092,7 +1089,7 @@ BOOST_MATH_GPU_ENABLED inline T tgamma_small_upper_part(T a, T x, const Policy& 
    result -= p;
    result /= a;
    detail::small_gamma2_series<T> s(a, x);
-   std::uintmax_t max_iter = policies::get_max_series_iterations<Policy>() - 10;
+   boost::math::uintmax_t max_iter = policies::get_max_series_iterations<Policy>() - 10;
    p += 1;
    if(pderivative)
       *pderivative = p / (*pgam * exp(x));
@@ -1192,7 +1189,7 @@ BOOST_MATH_GPU_ENABLED T incomplete_tgamma_large_x(const T& a, const T& x, const
 {
    BOOST_MATH_STD_USING
    incomplete_tgamma_large_x_series<T> s(a, x);
-   std::uintmax_t max_iter = boost::math::policies::get_max_series_iterations<Policy>();
+   boost::math::uintmax_t max_iter = boost::math::policies::get_max_series_iterations<Policy>();
    T result = boost::math::tools::sum_series(s, boost::math::policies::get_epsilon<T, Policy>(), max_iter);
    boost::math::policies::check_series_iterations<T>("boost::math::tgamma<%1%>(%1%,%1%)", max_iter, pol);
    return result;
@@ -1357,7 +1354,7 @@ BOOST_MATH_GPU_ENABLED T gamma_incomplete_imp(T a, T x, bool normalised, bool in
       // series and continued fractions are slow to converge:
       //
       bool use_temme = false;
-      if(normalised && std::numeric_limits<T>::is_specialized && (a > 20))
+      if(normalised && boost::math::numeric_limits<T>::is_specialized && (a > 20))
       {
          T sigma = fabs((x-a)/a);
          if((a > 200) && (policies::digits<T, Policy>() <= 113))
@@ -1507,7 +1504,7 @@ BOOST_MATH_GPU_ENABLED T gamma_incomplete_imp(T a, T x, bool normalised, bool in
          //
          typedef typename policies::precision<T, Policy>::type precision_type;
 
-         typedef std::integral_constant<int,
+         typedef boost::math::integral_constant<int,
             precision_type::value <= 0 ? 0 :
             precision_type::value <= 53 ? 53 :
             precision_type::value <= 64 ? 64 :
@@ -1901,7 +1898,7 @@ struct igamma_initializer
       {
          typedef typename policies::precision<T, Policy>::type precision_type;
 
-         typedef std::integral_constant<int,
+         typedef boost::math::integral_constant<int,
             precision_type::value <= 0 ? 0 :
             precision_type::value <= 53 ? 53 :
             precision_type::value <= 64 ? 64 :
@@ -1911,18 +1908,18 @@ struct igamma_initializer
          do_init(tag_type());
       }
       template <int N>
-      BOOST_MATH_GPU_ENABLED static void do_init(const std::integral_constant<int, N>&)
+      BOOST_MATH_GPU_ENABLED static void do_init(const boost::math::integral_constant<int, N>&)
       {
          // If std::numeric_limits<T>::digits is zero, we must not call
          // our initialization code here as the precision presumably
          // varies at runtime, and will not have been set yet.  Plus the
          // code requiring initialization isn't called when digits == 0.
-         if (std::numeric_limits<T>::digits)
+         if (boost::math::numeric_limits<T>::digits)
          {
             boost::math::gamma_p(static_cast<T>(400), static_cast<T>(400), Policy());
          }
       }
-      BOOST_MATH_GPU_ENABLED static void do_init(const std::integral_constant<int, 53>&){}
+      BOOST_MATH_GPU_ENABLED static void do_init(const boost::math::integral_constant<int, 53>&){}
       void force_instantiate()const{}
    };
    BOOST_MATH_STATIC const init initializer;
@@ -1945,7 +1942,7 @@ struct lgamma_initializer
       BOOST_MATH_GPU_ENABLED init()
       {
          typedef typename policies::precision<T, Policy>::type precision_type;
-         typedef std::integral_constant<int,
+         typedef boost::math::integral_constant<int,
             precision_type::value <= 0 ? 0 :
             precision_type::value <= 64 ? 64 :
             precision_type::value <= 113 ? 113 : 0
@@ -1953,20 +1950,20 @@ struct lgamma_initializer
 
          do_init(tag_type());
       }
-      BOOST_MATH_GPU_ENABLED static void do_init(const std::integral_constant<int, 64>&)
+      BOOST_MATH_GPU_ENABLED static void do_init(const boost::math::integral_constant<int, 64>&)
       {
          boost::math::lgamma(static_cast<T>(2.5), Policy());
          boost::math::lgamma(static_cast<T>(1.25), Policy());
          boost::math::lgamma(static_cast<T>(1.75), Policy());
       }
-      BOOST_MATH_GPU_ENABLED static void do_init(const std::integral_constant<int, 113>&)
+      BOOST_MATH_GPU_ENABLED static void do_init(const boost::math::integral_constant<int, 113>&)
       {
          boost::math::lgamma(static_cast<T>(2.5), Policy());
          boost::math::lgamma(static_cast<T>(1.25), Policy());
          boost::math::lgamma(static_cast<T>(1.5), Policy());
          boost::math::lgamma(static_cast<T>(1.75), Policy());
       }
-      BOOST_MATH_GPU_ENABLED static void do_init(const std::integral_constant<int, 0>&)
+      BOOST_MATH_GPU_ENABLED static void do_init(const boost::math::integral_constant<int, 0>&)
       {
       }
       BOOST_MATH_GPU_ENABLED void force_instantiate()const{}
@@ -2079,7 +2076,7 @@ BOOST_MATH_GPU_ENABLED inline typename tools::promote_args<T>::type
       policies::discrete_quantile<>,
       policies::assert_undefined<> >::type forwarding_policy;
 
-   return policies::checked_narrowing_cast<typename std::remove_cv<result_type>::type, forwarding_policy>(detail::tgammap1m1_imp(static_cast<value_type>(z), forwarding_policy(), evaluation_type()), "boost::math::tgamma1pm1<%!%>(%1%)");
+   return policies::checked_narrowing_cast<typename boost::math::remove_cv<result_type>::type, forwarding_policy>(detail::tgammap1m1_imp(static_cast<value_type>(z), forwarding_policy(), evaluation_type()), "boost::math::tgamma1pm1<%!%>(%1%)");
 }
 
 template <class T>
@@ -2283,74 +2280,5 @@ BOOST_MATH_GPU_ENABLED inline tools::promote_args_t<T1, T2>
 #include <boost/math/special_functions/detail/igamma_inverse.hpp>
 #include <boost/math/special_functions/detail/gamma_inva.hpp>
 #include <boost/math/special_functions/erf.hpp>
-
-#else
-
-#include <boost/math/tools/config.hpp>
-#include <boost/math/special_functions/expm1.hpp>
-
-namespace boost {
-namespace math {
-
-inline BOOST_MATH_GPU_ENABLED float tgamma(float x) { return ::tgammaf(x); }
-inline BOOST_MATH_GPU_ENABLED double tgamma(double x) { return ::tgamma(x); }
-
-template <typename T, typename Policy>
-BOOST_MATH_GPU_ENABLED T tgamma(T x, const Policy&)
-{
-   return boost::math::tgamma(x);
-}
-
-inline BOOST_MATH_GPU_ENABLED float lgamma(float x) { return ::lgammaf(x); }
-inline BOOST_MATH_GPU_ENABLED double lgamma(double x) { return ::lgamma(x); }
-
-template <typename T, typename Policy>
-BOOST_MATH_GPU_ENABLED T lgamma(T x, const Policy&)
-{
-   return boost::math::lgamma(x);
-}
-
-template <typename T, typename Policy>
-BOOST_MATH_GPU_ENABLED T lgamma(T x, int* sign, const Policy&)
-{
-   auto res = boost::math::lgamma(x);
-   if (sign != nullptr)
-   {
-      if (res < 0)
-      {
-         *sign = -1;
-      }
-      else
-      {
-         *sign = 1;
-      }
-   }
-
-   return res;
-}
-
-template <typename T>
-BOOST_MATH_GPU_ENABLED T tgamma1pm1(T z)
-{
-   using namespace boost::math;
-
-   if (fabs(z) < T(0.55))
-   {
-      return expm1(lgamma(z));
-   }
-
-   return expm1(lgamma(1 + z));
-}
-
-template <typename T, typename Policy>
-BOOST_MATH_GPU_ENABLED T tgamma1pm1(T x, const Policy&)
-{
-   return tgamma1pm1(x);
-}
-
-} // namespace math
-} // namespace boost
-
-#endif // __CUDACC_RTC__
 
 #endif // BOOST_MATH_SF_GAMMA_HPP

--- a/include/boost/math/special_functions/gamma.hpp
+++ b/include/boost/math/special_functions/gamma.hpp
@@ -411,7 +411,7 @@ BOOST_MATH_GPU_ENABLED inline T lower_gamma_series(T a, T z, const Policy& pol, 
 // with Bernoulli numbers.
 //
 template<class T>
-std::size_t highest_bernoulli_index()
+BOOST_MATH_GPU_ENABLED boost::math::size_t highest_bernoulli_index()
 {
    const float digits10_of_type = (std::numeric_limits<T>::is_specialized
                                       ? static_cast<float>(std::numeric_limits<T>::digits10)
@@ -422,7 +422,7 @@ std::size_t highest_bernoulli_index()
 }
 
 template<class T>
-int minimum_argument_for_bernoulli_recursion()
+BOOST_MATH_GPU_ENABLED int minimum_argument_for_bernoulli_recursion()
 {
    BOOST_MATH_STD_USING
 
@@ -456,7 +456,7 @@ int minimum_argument_for_bernoulli_recursion()
 }
 
 template <class T, class Policy>
-T scaled_tgamma_no_lanczos(const T& z, const Policy& pol, bool islog = false)
+BOOST_MATH_GPU_ENABLED T scaled_tgamma_no_lanczos(const T& z, const Policy& pol, bool islog = false)
 {
    BOOST_MATH_STD_USING
    //

--- a/include/boost/math/special_functions/math_fwd.hpp
+++ b/include/boost/math/special_functions/math_fwd.hpp
@@ -512,28 +512,28 @@ namespace boost
 
    // gamma inverse.
    template <class T1, class T2>
-   tools::promote_args_t<T1, T2> gamma_p_inv(T1 a, T2 p);
+   BOOST_MATH_GPU_ENABLED tools::promote_args_t<T1, T2> gamma_p_inv(T1 a, T2 p);
 
    template <class T1, class T2, class Policy>
-   tools::promote_args_t<T1, T2> gamma_p_inva(T1 a, T2 p, const Policy&);
+   BOOST_MATH_GPU_ENABLED tools::promote_args_t<T1, T2> gamma_p_inva(T1 a, T2 p, const Policy&);
 
    template <class T1, class T2>
-   tools::promote_args_t<T1, T2> gamma_p_inva(T1 a, T2 p);
+   BOOST_MATH_GPU_ENABLED tools::promote_args_t<T1, T2> gamma_p_inva(T1 a, T2 p);
 
    template <class T1, class T2, class Policy>
-   tools::promote_args_t<T1, T2> gamma_p_inv(T1 a, T2 p, const Policy&);
+   BOOST_MATH_GPU_ENABLED tools::promote_args_t<T1, T2> gamma_p_inv(T1 a, T2 p, const Policy&);
 
    template <class T1, class T2>
-   tools::promote_args_t<T1, T2> gamma_q_inv(T1 a, T2 q);
+   BOOST_MATH_GPU_ENABLED tools::promote_args_t<T1, T2> gamma_q_inv(T1 a, T2 q);
 
    template <class T1, class T2, class Policy>
-   tools::promote_args_t<T1, T2> gamma_q_inv(T1 a, T2 q, const Policy&);
+   BOOST_MATH_GPU_ENABLED tools::promote_args_t<T1, T2> gamma_q_inv(T1 a, T2 q, const Policy&);
 
    template <class T1, class T2>
-   tools::promote_args_t<T1, T2> gamma_q_inva(T1 a, T2 q);
+   BOOST_MATH_GPU_ENABLED tools::promote_args_t<T1, T2> gamma_q_inva(T1 a, T2 q);
 
    template <class T1, class T2, class Policy>
-   tools::promote_args_t<T1, T2> gamma_q_inva(T1 a, T2 q, const Policy&);
+   BOOST_MATH_GPU_ENABLED tools::promote_args_t<T1, T2> gamma_q_inva(T1 a, T2 q, const Policy&);
 
    // digamma:
    template <class T>
@@ -1133,31 +1133,31 @@ namespace boost
    tools::promote_args_t<T, U> epsilon_difference(const T&, const U&);
 
    template<class T>
-   BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_b2n(const std::size_t n);
+   BOOST_MATH_GPU_ENABLED BOOST_MATH_CONSTEXPR_TABLE_FUNCTION T unchecked_bernoulli_b2n(const std::size_t n);
    template <class T, class Policy>
-   T bernoulli_b2n(const int i, const Policy &pol);
+   BOOST_MATH_GPU_ENABLED T bernoulli_b2n(const int i, const Policy &pol);
    template <class T>
-   T bernoulli_b2n(const int i);
+   BOOST_MATH_GPU_ENABLED T bernoulli_b2n(const int i);
    template <class T, class OutputIterator, class Policy>
-   OutputIterator bernoulli_b2n(const int start_index,
+   BOOST_MATH_GPU_ENABLED OutputIterator bernoulli_b2n(const int start_index,
                                        const unsigned number_of_bernoullis_b2n,
                                        OutputIterator out_it,
                                        const Policy& pol);
    template <class T, class OutputIterator>
-   OutputIterator bernoulli_b2n(const int start_index,
+   BOOST_MATH_GPU_ENABLED OutputIterator bernoulli_b2n(const int start_index,
                                        const unsigned number_of_bernoullis_b2n,
                                        OutputIterator out_it);
    template <class T, class Policy>
-   T tangent_t2n(const int i, const Policy &pol);
+   BOOST_MATH_GPU_ENABLED T tangent_t2n(const int i, const Policy &pol);
    template <class T>
-   T tangent_t2n(const int i);
+   BOOST_MATH_GPU_ENABLED T tangent_t2n(const int i);
    template <class T, class OutputIterator, class Policy>
-   OutputIterator tangent_t2n(const int start_index,
+   BOOST_MATH_GPU_ENABLED OutputIterator tangent_t2n(const int start_index,
                                        const unsigned number_of_bernoullis_b2n,
                                        OutputIterator out_it,
                                        const Policy& pol);
    template <class T, class OutputIterator>
-   OutputIterator tangent_t2n(const int start_index,
+   BOOST_MATH_GPU_ENABLED OutputIterator tangent_t2n(const int start_index,
                                        const unsigned number_of_bernoullis_b2n,
                                        OutputIterator out_it);
 
@@ -1447,16 +1447,16 @@ namespace boost
    BOOST_MATH_GPU_ENABLED inline boost::math::tools::promote_args_t<T1, T2> gamma_p_derivative(T1 a, T2 x){ return boost::math::gamma_p_derivative(a, x, Policy()); }\
 \
    template <class T1, class T2>\
-   inline boost::math::tools::promote_args_t<T1, T2> gamma_p_inv(T1 a, T2 p){ return boost::math::gamma_p_inv(a, p, Policy()); }\
+   BOOST_MATH_GPU_ENABLED inline boost::math::tools::promote_args_t<T1, T2> gamma_p_inv(T1 a, T2 p){ return boost::math::gamma_p_inv(a, p, Policy()); }\
 \
    template <class T1, class T2>\
-   inline boost::math::tools::promote_args_t<T1, T2> gamma_p_inva(T1 a, T2 p){ return boost::math::gamma_p_inva(a, p, Policy()); }\
+   BOOST_MATH_GPU_ENABLED inline boost::math::tools::promote_args_t<T1, T2> gamma_p_inva(T1 a, T2 p){ return boost::math::gamma_p_inva(a, p, Policy()); }\
 \
    template <class T1, class T2>\
-   inline boost::math::tools::promote_args_t<T1, T2> gamma_q_inv(T1 a, T2 q){ return boost::math::gamma_q_inv(a, q, Policy()); }\
+   BOOST_MATH_GPU_ENABLED inline boost::math::tools::promote_args_t<T1, T2> gamma_q_inv(T1 a, T2 q){ return boost::math::gamma_q_inv(a, q, Policy()); }\
 \
    template <class T1, class T2>\
-   inline boost::math::tools::promote_args_t<T1, T2> gamma_q_inva(T1 a, T2 q){ return boost::math::gamma_q_inva(a, q, Policy()); }\
+   BOOST_MATH_GPU_ENABLED inline boost::math::tools::promote_args_t<T1, T2> gamma_q_inva(T1 a, T2 q){ return boost::math::gamma_q_inva(a, q, Policy()); }\
 \
    template <class T>\
    BOOST_MATH_GPU_ENABLED inline boost::math::tools::promote_args_t<T> digamma(T x){ return boost::math::digamma(x, Policy()); }\
@@ -1787,17 +1787,17 @@ template <class OutputIterator, class T>\
    { return boost::math::airy_bi_zero<T>(start_index, number_of_zeros, out_it, Policy()); }\
    \
    template <class T>\
-   T bernoulli_b2n(const int i)\
+   BOOST_MATH_GPU_ENABLED T bernoulli_b2n(const int i)\
    { return boost::math::bernoulli_b2n<T>(i, Policy()); }\
    template <class T, class OutputIterator>\
-   OutputIterator bernoulli_b2n(int start_index, unsigned number_of_bernoullis_b2n, OutputIterator out_it)\
+   BOOST_MATH_GPU_ENABLED OutputIterator bernoulli_b2n(int start_index, unsigned number_of_bernoullis_b2n, OutputIterator out_it)\
    { return boost::math::bernoulli_b2n<T>(start_index, number_of_bernoullis_b2n, out_it, Policy()); }\
    \
    template <class T>\
-   T tangent_t2n(const int i)\
+   BOOST_MATH_GPU_ENABLED T tangent_t2n(const int i)\
    { return boost::math::tangent_t2n<T>(i, Policy()); }\
    template <class T, class OutputIterator>\
-   OutputIterator tangent_t2n(int start_index, unsigned number_of_bernoullis_b2n, OutputIterator out_it)\
+   BOOST_MATH_GPU_ENABLED OutputIterator tangent_t2n(int start_index, unsigned number_of_bernoullis_b2n, OutputIterator out_it)\
    { return boost::math::tangent_t2n<T>(start_index, number_of_bernoullis_b2n, out_it, Policy()); }\
    \
    template <class T> inline boost::math::tools::promote_args_t<T> lambert_w0(T z) { return boost::math::lambert_w0(z, Policy()); }\

--- a/include/boost/math/tools/algorithm.hpp
+++ b/include/boost/math/tools/algorithm.hpp
@@ -37,7 +37,7 @@ BOOST_MATH_GPU_ENABLED void fill(ForwardIt first, ForwardIt last, const T& value
 }
 
 template <typename OutputIt, typename Size, typename T>
-OutputIt fill_n(OutputIt first, Size count, const T& value)
+BOOST_MATH_GPU_ENABLED OutputIt fill_n(OutputIt first, Size count, const T& value)
 {
     for (Size i = 0; i < count; i++)
     {

--- a/include/boost/math/tools/algorithm.hpp
+++ b/include/boost/math/tools/algorithm.hpp
@@ -1,0 +1,55 @@
+//  Copyright (c) 2024 Matt Borland
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_TOOLS_ALGORITHM_HPP
+#define BOOST_MATH_TOOLS_ALGORITHM_HPP
+
+#include <boost/math/tools/config.hpp>
+
+#ifndef BOOST_MATH_ENABLE_CUDA
+
+#include <algorithm>
+
+namespace boost {
+namespace math {
+
+using std::fill;
+using std::fill_n;
+
+} // namespace math
+} // namespace boost
+
+#else
+
+namespace boost {
+namespace math {
+
+template <typename ForwardIt, typename T>
+BOOST_MATH_GPU_ENABLED void fill(ForwardIt first, ForwardIt last, const T& value)
+{
+    while (first != last)
+    {
+        *first = value;
+        ++first;
+    }
+}
+
+template <typename OutputIt, typename Size, typename T>
+OutputIt fill_n(OutputIt first, Size count, const T& value)
+{
+    for (Size i = 0; i < count; i++)
+    {
+        *first++ = value;
+    }
+
+    return first;
+}
+
+} // Namespace math
+} // Namespace boost
+
+#endif // CUDA algos
+
+#endif // BOOST_MATH_TOOLS_ALGORITHM_HPP

--- a/include/boost/math/tools/polynomial.hpp
+++ b/include/boost/math/tools/polynomial.hpp
@@ -13,6 +13,10 @@
 #pragma once
 #endif
 
+#include <boost/math/tools/config.hpp>
+
+#ifndef BOOST_MATH_HAS_GPU_SUPPORT
+
 #include <boost/math/tools/assert.hpp>
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/cxx03_warn.hpp>
@@ -858,5 +862,7 @@ BOOST_MATH_GPU_ENABLED inline std::basic_ostream<charT, traits>& operator << (st
 // Polynomial specific overload of gcd algorithm:
 //
 #include <boost/math/tools/polynomial_gcd.hpp>
+
+#endif // GPU
 
 #endif // BOOST_MATH_TOOLS_POLYNOMIAL_HPP

--- a/include/boost/math/tools/series.hpp
+++ b/include/boost/math/tools/series.hpp
@@ -14,6 +14,7 @@
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/numeric_limits.hpp>
 #include <boost/math/tools/cstdint.hpp>
+#include <boost/math/tools/type_traits.hpp>
 
 namespace boost{ namespace math{ namespace tools{
 

--- a/include/boost/math/tools/throw_exception.hpp
+++ b/include/boost/math/tools/throw_exception.hpp
@@ -6,6 +6,10 @@
 #ifndef BOOST_MATH_TOOLS_THROW_EXCEPTION_HPP
 #define BOOST_MATH_TOOLS_THROW_EXCEPTION_HPP
 
+#include <boost/math/tools/config.hpp>
+
+#ifndef BOOST_MATH_HAS_GPU_SUPPORT
+
 #include <boost/math/tools/is_standalone.hpp>
 
 #ifndef BOOST_MATH_STANDALONE
@@ -39,5 +43,11 @@
 #endif
 
 #endif // BOOST_MATH_STANDALONE
+
+#else // BOOST_MATH_GPU_SUPPORT
+
+#define BOOST_MATH_THROW_EXCEPTION(expr)
+
+#endif 
 
 #endif // BOOST_MATH_TOOLS_THROW_EXCEPTION_HPP

--- a/include/boost/math/tools/vector.hpp
+++ b/include/boost/math/tools/vector.hpp
@@ -33,7 +33,7 @@ namespace math {
 
 template <typename T>
 class vector {
-private:
+protected:
     T* data;
     boost::math::size_t capacity_;
     boost::math::size_t current_;
@@ -162,6 +162,25 @@ public:
         return current_ == 0;
     }
 
+    BOOST_MATH_GPU_ENABLED T* begin()
+    {
+        return data;
+    }
+
+    BOOST_MATH_GPU_ENABLED T* begin() const
+    {
+        return data;
+    }
+
+    BOOST_MATH_GPU_ENABLED T* end()
+    {
+        return data + current_;
+    }
+
+    BOOST_MATH_GPU_ENABLED T* end() const
+    {
+        return data + current_;
+    }
 };
 
 } // Namespace math

--- a/include/boost/math/tools/vector.hpp
+++ b/include/boost/math/tools/vector.hpp
@@ -1,0 +1,172 @@
+//  Copyright (c) 2024 Matt Borland
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+//  Regular use of <vector> is not supported by CUDA
+//  And thrust::device_vector does not work on NVRTC
+//  Roll our own implmentation of vector using CUDA 
+
+#ifndef BOOST_MATH_TOOLS_VECTOR_HPP
+#define BOOST_MATH_TOOLS_VECTOR_HPP
+
+#include <boost/math/tools/config.hpp>
+#include <boost/math/tools/cstdint.hpp>
+#include <boost/math/tools/type_traits.hpp>
+
+#ifndef BOOST_MATH_ENABLE_CUDA
+
+#include <vector>
+
+namespace boost {
+namespace math {
+
+using std::vector;
+
+} // namespace math
+} // namespace boost
+
+#else // CUDA capable vector
+
+namespace boost {
+namespace math {
+
+template <typename T>
+class vector {
+private:
+    T* data;
+    boost::math::size_t capacity_;
+    boost::math::size_t current_;
+
+public:
+    BOOST_MATH_GPU_ENABLED vector()
+    {
+        // cudaMalloc takes void** instead of void* like malloc
+        data = cudaMalloc(&data, sizeof(T));
+        if (data != nullptr)
+        {
+            capacity_ = 1;
+        }
+        else
+        {
+            capacity_ = 0;
+        }
+
+        current_ = 0;
+    }
+
+    BOOST_MATH_GPU_ENABLED ~vector()
+    {
+        if (data != nullptr)
+        {
+            clear();
+            cudaFree(data);
+            data = nullptr;
+        }
+    }
+
+    BOOST_MATH_GPU_ENABLED void push_back(T element)
+    {
+        if (current_ == capacity_)
+        {
+            T* temp;
+            temp = cudaMalloc(&temp, 2 * capacity_ * sizeof(T));
+
+            if (temp == nullptr)
+            {
+                // We have no more memory so we can't add the element
+                // We also can't throw or write to errno to signal ENOMEM
+                return;
+            }
+
+            for (boost::math::size_t i = 0; i < capacity_; ++ i)
+            {
+                temp[i] = data[i];
+            }
+
+            cudaFree(data);
+            capacity_ *= 2;
+            data = temp;
+        }
+
+        data[current_] = element;
+        ++current_;
+    }
+
+    BOOST_MATH_GPU_ENABLED void resize(boost::math::size_t new_size, T default_elem)
+    {
+        if (data != nullptr)
+        {
+            cudaFree(data);
+        }
+
+        data = cudaMalloc(&data, new_size * sizeof(T));
+        
+        if (data != nullptr)
+        {
+            current_ = 0;
+            capacity_ = new_size;
+
+            // cudaMemset only works with ints so we need to loop
+            for (boost::math::size_t i = 0; i < capacity_; ++i)
+            {
+                data[i] = default_elem;
+            }
+        }
+    }
+
+    BOOST_MATH_GPU_ENABLED void clear()
+    {
+        // Destroy all the elements (if applicable), but don't resize the vector
+        BOOST_MATH_IF_CONSTEXPR (!boost::math::is_trivial_v<T>)
+        {
+            for (boost::math::size_t i = 0; i < current_; ++i) 
+            {
+                data[i].~T();
+            }
+        }
+
+        current_ = 0;
+    }
+
+    BOOST_MATH_GPU_ENABLED void resize(boost::math::size_t new_size)
+    {
+        resize(new_size, static_cast<T>(0));
+    }
+
+    BOOST_MATH_GPU_ENABLED void pop_back()
+    {
+        if (current_ > 0)
+        {
+            --current_;
+        }
+    }
+
+    BOOST_MATH_GPU_ENABLED T& operator[](boost::math::size_t index)
+    {
+        return data[index];
+    }
+
+    BOOST_MATH_GPU_ENABLED boost::math::size_t size() const
+    {
+        return current_;
+    }
+
+    BOOST_MATH_GPU_ENABLED boost::math::size_t capacity() const
+    {
+        return capacity_;
+    }
+
+    BOOST_MATH_GPU_ENABLED bool empty() const 
+    {
+        return current_ == 0;
+    }
+
+};
+
+} // Namespace math
+} // Namespace boost
+
+#endif // CUDA vector
+
+#endif // BOOST_MATH_TOOLS_VECTOR_HPP

--- a/test/cuda_jamfile
+++ b/test/cuda_jamfile
@@ -95,6 +95,9 @@ run test_saspoint5_quan_float.cu ;
 run test_beta_double.cu ;
 run test_beta_float.cu ;
 
+run test_bernoulli_constants_double.cu ;
+run test_bernoulli_constants_float.cu ;
+
 run test_bessel_i0_double.cu ;
 run test_bessel_i0_float.cu ;
 run test_bessel_i1_double.cu ;

--- a/test/test_bernoulli_constants_double.cu
+++ b/test/test_bernoulli_constants_double.cu
@@ -1,0 +1,103 @@
+
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <boost/math/special_functions.hpp>
+#include "cuda_managed_ptr.hpp"
+#include "stopwatch.hpp"
+
+// For the CUDA runtime routines (prefixed with "cuda_")
+#include <cuda_runtime.h>
+
+typedef double float_type;
+
+/**
+ * CUDA Kernel Device code
+ *
+ */
+__global__ void cuda_test(const float_type *in, float_type *out, int numElements)
+{
+    using std::cos;
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+
+    if (i < numElements)
+    {
+        out[i] = boost::math::bernoulli_b2n<float_type>(static_cast<int>(in[i]));
+    }
+}
+
+/**
+ * Host main routine
+ */
+int main(void)
+{
+    // Error code to check return values for CUDA calls
+    cudaError_t err = cudaSuccess;
+
+    // Print the vector length to be used, and compute its size
+    int numElements = 50000;
+    std::cout << "[Vector operation on " << numElements << " elements]" << std::endl;
+
+    // Allocate the managed input vector A
+    cuda_managed_ptr<float_type> input_vector(numElements);
+
+    // Allocate the managed output vector C
+    cuda_managed_ptr<float_type> output_vector(numElements);
+
+    // Initialize the input vectors
+    std::mt19937_64 gen(42);
+    std::uniform_real_distribution<float_type> dist(0, 10);
+    for (int i = 0; i < numElements; ++i)
+    {
+        input_vector[i] = dist(gen);
+    }
+
+    // Launch the Vector Add CUDA Kernel
+    int threadsPerBlock = 256;
+    int blocksPerGrid =(numElements + threadsPerBlock - 1) / threadsPerBlock;
+    std::cout << "CUDA kernel launch with " << blocksPerGrid << " blocks of " << threadsPerBlock << " threads" << std::endl;
+
+    watch w;
+
+    cuda_test<<<blocksPerGrid, threadsPerBlock>>>(input_vector.get(), output_vector.get(), numElements);
+    cudaDeviceSynchronize();
+
+    std::cout << "CUDA kernal done in: " << w.elapsed() << "s" << std::endl;
+
+    err = cudaGetLastError();
+
+    if (err != cudaSuccess)
+    {
+        std::cerr << "Failed to launch vectorAdd kernel (error code " << cudaGetErrorString(err) << ")!" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Verify that the result vector is correct
+    std::vector<float_type> results;
+    results.reserve(numElements);
+    w.reset();
+    for(int i = 0; i < numElements; ++i)
+       results.push_back(boost::math::bernoulli_b2n<float_type>(static_cast<int>(input_vector[i])));
+    double t = w.elapsed();
+    // check the results
+    for(int i = 0; i < numElements; ++i)
+    {
+        if (boost::math::epsilon_difference(output_vector[i], results[i]) > 10)
+        {
+            std::cerr << "Result verification failed at element " << i << "!" << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+
+    std::cout << "Test PASSED, normal calculation time: " << t << "s" << std::endl;
+    std::cout << "Done\n";
+
+    return 0;
+}

--- a/test/test_bernoulli_constants_float.cu
+++ b/test/test_bernoulli_constants_float.cu
@@ -1,0 +1,103 @@
+
+//  Copyright John Maddock 2016.
+//  Copyright Matt Borland 2024.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <random>
+#include <boost/math/special_functions.hpp>
+#include "cuda_managed_ptr.hpp"
+#include "stopwatch.hpp"
+
+// For the CUDA runtime routines (prefixed with "cuda_")
+#include <cuda_runtime.h>
+
+typedef float float_type;
+
+/**
+ * CUDA Kernel Device code
+ *
+ */
+__global__ void cuda_test(const float_type *in, float_type *out, int numElements)
+{
+    using std::cos;
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+
+    if (i < numElements)
+    {
+        out[i] = boost::math::bernoulli_b2n<float_type>(static_cast<int>(in[i]));
+    }
+}
+
+/**
+ * Host main routine
+ */
+int main(void)
+{
+    // Error code to check return values for CUDA calls
+    cudaError_t err = cudaSuccess;
+
+    // Print the vector length to be used, and compute its size
+    int numElements = 50000;
+    std::cout << "[Vector operation on " << numElements << " elements]" << std::endl;
+
+    // Allocate the managed input vector A
+    cuda_managed_ptr<float_type> input_vector(numElements);
+
+    // Allocate the managed output vector C
+    cuda_managed_ptr<float_type> output_vector(numElements);
+
+    // Initialize the input vectors
+    std::mt19937_64 gen(42);
+    std::uniform_real_distribution<float_type> dist(0, 10);
+    for (int i = 0; i < numElements; ++i)
+    {
+        input_vector[i] = dist(gen);
+    }
+
+    // Launch the Vector Add CUDA Kernel
+    int threadsPerBlock = 256;
+    int blocksPerGrid =(numElements + threadsPerBlock - 1) / threadsPerBlock;
+    std::cout << "CUDA kernel launch with " << blocksPerGrid << " blocks of " << threadsPerBlock << " threads" << std::endl;
+
+    watch w;
+
+    cuda_test<<<blocksPerGrid, threadsPerBlock>>>(input_vector.get(), output_vector.get(), numElements);
+    cudaDeviceSynchronize();
+
+    std::cout << "CUDA kernal done in: " << w.elapsed() << "s" << std::endl;
+
+    err = cudaGetLastError();
+
+    if (err != cudaSuccess)
+    {
+        std::cerr << "Failed to launch vectorAdd kernel (error code " << cudaGetErrorString(err) << ")!" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Verify that the result vector is correct
+    std::vector<float_type> results;
+    results.reserve(numElements);
+    w.reset();
+    for(int i = 0; i < numElements; ++i)
+       results.push_back(boost::math::bernoulli_b2n<float_type>(static_cast<int>(input_vector[i])));
+    double t = w.elapsed();
+    // check the results
+    for(int i = 0; i < numElements; ++i)
+    {
+        if (boost::math::epsilon_difference(output_vector[i], results[i]) > 10)
+        {
+            std::cerr << "Result verification failed at element " << i << "!" << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+
+    std::cout << "Test PASSED, normal calculation time: " << t << "s" << std::endl;
+    std::cout << "Done\n";
+
+    return 0;
+}

--- a/test/test_log1p_nvrtc_double.cpp
+++ b/test/test_log1p_nvrtc_double.cpp
@@ -85,9 +85,9 @@ int main()
         nvrtcAddNameExpression(prog, "test_log1p_kernel");
 
         #ifdef BOOST_MATH_NVRTC_CI_RUN
-        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/"};
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
         #else
-        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/"};
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
         #endif
 
         // Compile the program

--- a/test/test_log1p_nvrtc_float.cpp
+++ b/test/test_log1p_nvrtc_float.cpp
@@ -7,6 +7,11 @@
 #define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
 #define BOOST_MATH_PROMOTE_DOUBLE_POLICY false
 
+// Must be included first
+#include <nvrtc.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
 #include <iostream>
 #include <iomanip>
 #include <vector>
@@ -14,9 +19,6 @@
 #include <exception>
 #include <boost/math/special_functions/log1p.hpp>
 #include <boost/math/special_functions/relative_difference.hpp>
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <nvrtc.h>
 
 typedef float float_type;
 
@@ -85,9 +87,9 @@ int main()
         nvrtcAddNameExpression(prog, "test_log1p_kernel");
 
         #ifdef BOOST_MATH_NVRTC_CI_RUN
-        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/"};
+        const char* opts[] = {"--std=c++14", "--gpu-architecture=compute_75", "--include-path=/home/runner/work/cuda-math/boost-root/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
         #else
-        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/"};
+        const char* opts[] = {"--std=c++14", "--include-path=/home/mborland/Documents/boost/libs/cuda-math/include/", "-I/usr/local/cuda/include"};
         #endif
 
         // Compile the program


### PR DESCRIPTION
Adds: bernoulli numbers, home rolled version of vector that is compatible with CUDA, and GPU capable `fill` and `fill_n`

Removes: Workaround for log1p 